### PR TITLE
update examples in `R` side

### DIFF
--- a/R/embedded.R
+++ b/R/embedded.R
@@ -29,7 +29,12 @@ methods::setGeneric("embedded", function(data, ...) standardGeneric("embedded"))
 #'
 #' @examples
 #' columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
-#' embedded(columbus,target = "crime", E = 3)
+#' v = embedded(columbus,"crime")
+#' v[1:5,]
+#'
+#' cu = terra::rast(system.file("case/cu.tif", package="spEDM"))
+#' r = embedd(cu,"cu")
+#' r[1:5,]
 #'
 methods::setMethod("embedded", "sf", .embedded_sf_method)
 

--- a/R/simplex.R
+++ b/R/simplex.R
@@ -43,7 +43,7 @@ methods::setGeneric("simplex", function(data, ...) standardGeneric("simplex"))
 #' @examples
 #' columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
 #' \donttest{
-#' simplex(columbus,target = "crime")
+#' simplex(columbus,"crime")
 #' }
 methods::setMethod("simplex", "sf", .simplex_sf_method)
 

--- a/R/smap.R
+++ b/R/smap.R
@@ -44,7 +44,7 @@ methods::setGeneric("smap", function(data, ...) standardGeneric("smap"))
 #' @examples
 #' columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
 #' \donttest{
-#' smap(columbus,target = "inc")
+#' smap(columbus,"inc")
 #' }
 methods::setMethod("smap", "sf", .smap_sf_method)
 

--- a/man/embedded.Rd
+++ b/man/embedded.Rd
@@ -31,6 +31,11 @@ embedding spatial cross sectional data
 }
 \examples{
 columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
-embedded(columbus,target = "crime", E = 3)
+v = embedded(columbus,"crime")
+v[1:5,]
+
+cu = terra::rast(system.file("case/cu.tif", package="spEDM"))
+r = embedd(cu,"cu")
+r[1:5,]
 
 }

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -65,7 +65,7 @@ simplex forecast
 \examples{
 columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
 \donttest{
-simplex(columbus,target = "crime")
+simplex(columbus,"crime")
 }
 }
 \references{

--- a/man/smap.Rd
+++ b/man/smap.Rd
@@ -71,7 +71,7 @@ smap forecast
 \examples{
 columbus = sf::read_sf(system.file("case/columbus.gpkg", package="spEDM"))
 \donttest{
-smap(columbus,target = "inc")
+smap(columbus,"inc")
 }
 }
 \references{


### PR DESCRIPTION
**feat(example): add raster data to test the impact of terra changes on spEDM**
- Add demonstration of grid data in example of `embedd` fun
- Remove unnecessary pre-set parameter usage in examples (`simplex` & `smap` & `embedd`)