### PR TITLE
docs(R API): update output description to clarify bidirectional causality testing

### DIFF
--- a/R/gccm.R
+++ b/R/gccm.R
@@ -88,9 +88,9 @@ methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
 #'
 #' @return A list
 #' \describe{
-#' \item{\code{xmap}}{cross mapping prediction results}
+#' \item{\code{xmap}}{cross mapping results}
 #' \item{\code{varname}}{names of causal and effect variable}
-#' \item{\code{bidirectional}}{whether to identify bidirectional causal associations}
+#' \item{\code{bidirectional}}{whether to examine bidirectional causality}
 #' }
 #' @export
 #' @importFrom methods setGeneric

--- a/R/gcmc.R
+++ b/R/gcmc.R
@@ -82,10 +82,12 @@ methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
 #' @param progressbar (optional) whether to print the progress bar.
 #'
 #' @return A list
-#'
+#' \describe{
+#' \item{\code{xmap}}{cross mapping results}
+#' \item{\code{varname}}{names of causal and effect variable}
+#' \item{\code{bidirectional}}{whether to examine bidirectional causality}
+#' }
 #' @export
-#' @importFrom methods setGeneric
-#' @importFrom methods setMethod
 #' @name gcmc
 #' @rdname gcmc
 #' @aliases gcmc,sf-method

--- a/man/gccm.Rd
+++ b/man/gccm.Rd
@@ -83,9 +83,9 @@
 \value{
 A list
 \describe{
-\item{\code{xmap}}{cross mapping prediction results}
+\item{\code{xmap}}{cross mapping results}
 \item{\code{varname}}{names of causal and effect variable}
-\item{\code{bidirectional}}{whether to identify bidirectional causal associations}
+\item{\code{bidirectional}}{whether to examine bidirectional causality}
 }
 }
 \description{

--- a/man/gcmc.Rd
+++ b/man/gcmc.Rd
@@ -70,6 +70,11 @@
 }
 \value{
 A list
+\describe{
+\item{\code{xmap}}{cross mapping results}
+\item{\code{varname}}{names of causal and effect variable}
+\item{\code{bidirectional}}{whether to examine bidirectional causality}
+}
 }
 \description{
 geographical cross mapping cardinality


### PR DESCRIPTION
- Revised the output documentation for the R-side API to improve clarity.
- Changed phrasing from "whether to identify bidirectional causal associations" to "whether to test for reverse causality."
- The new wording more accurately reflects the purpose of testing reverse (backward) causal relationships.
- No changes to API functionality; documentation update only.
