### PR TITLE
fix error from non-matrix input in grid-type handling due to R matrix slicing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 
 * Refine internal case data (#348).
 
+### bug fixes
+
+* Fix error from non-matrix input in grid-type handling due to R matrix slicing (#474).
+
 # spEDM 1.5
 
 ### new

--- a/R/variable_check_prepare.R
+++ b/R/variable_check_prepare.R
@@ -42,7 +42,7 @@
   } else {
     set.seed(seed)
     indices = sample(nrow(nnaindice), size = min(size,nrow(nnaindice)), replace = FALSE)
-    return(nnaindice[indices])
+    return(nnaindice[indices,])
   }
 }
 


### PR DESCRIPTION
``` r
library(spEDM)

npp = terra::rast(system.file("case/npp.tif", package = "spEDM"))
npp = terra::aggregate(npp, fact = 3, na.rm = TRUE)
npp
#> class       : SpatRaster 
#> dimensions  : 135, 161, 5  (nrow, ncol, nlyr)
#> resolution  : 30000, 30000  (x, y)
#> extent      : -2625763, 2204237, 1867078, 5917078  (xmin, xmax, ymin, ymax)
#> coord. ref. : CGCS2000_Albers 
#> source(s)   : memory
#> names       :      npp,        pre,      tem,      elev,         hfp 
#> min values  :   187.50,   390.3351, -47.8194, -110.1494,  0.04434316 
#> max values  : 15381.89, 23734.5330, 262.8576, 5217.6431, 42.68803711

gccm(data = npp,
     cause = "pre",
     effect = "npp",
     libsizes = as.matrix(expand.grid(130,160)),
     E = c(2,10),
     k = 8)
#> Error: Not a matrix.
```

<sup>Created on 2025-04-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
