### PR TITLE
fix input dimension handling bug in gcmc rcpp wrapper causing r session crash

### DIFF
--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -903,7 +903,7 @@ Rcpp::NumericMatrix RcppGCMC4Grid(
 
   // Convert Rcpp IntegerMatrix to std::vector<int>
   int n_libcol = lib.ncol();
-  int n_predcol = lib.ncol();
+  int n_predcol = pred.ncol();
   int numRows = yMatrix.nrow();
   int numCols = yMatrix.ncol();
 


### PR DESCRIPTION
In the previous implementation, the following codes could cause the R session to crash:
```r
cu = terra::rast(system.file("case/cu.tif", package="spEDM"))

spEDM::gcmc(cu, "ntl", "cu", E = 3, k = 300,
            #lib = as.matrix(which(terra::values(cu["cu"])>50)),
            pred = as.matrix(which(terra::values(cu["cu"])>50)))
```