### PR TITLE
refactor: remove `symbolize` and add `trend.rm` in `sgc` s4 generic

### DIFF
--- a/R/sgc.R
+++ b/R/sgc.R
@@ -1,26 +1,26 @@
 methods::setGeneric("sgc", function(data, ...) standardGeneric("sgc"))
 
 .sgc_sf_method = \(data, cause, effect, k, block = 3, boot = 399, seed = 42, base = 2, lib = NULL, pred = NULL,
-                   nb = NULL, threads = detectThreads(), symbolize = TRUE, normalize = FALSE, progressbar = FALSE){
+                   nb = NULL, threads = detectThreads(), trend.rm = TRUE, normalize = FALSE, progressbar = FALSE){
   varname = .check_character(cause, effect)
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   block = RcppDivideLattice(nb,block)
-  cause = .uni_lattice(data,cause,FALSE)
-  effect = .uni_lattice(data,effect,FALSE)
+  cause = .uni_lattice(data,cause,trend.rm)
+  effect = .uni_lattice(data,effect,trend.rm)
   if (is.null(lib)) lib = which(!(is.na(cause) | is.na(effect)))
   if (is.null(pred)) pred = lib
-  return(.bind_sc(RcppSGC4Lattice(cause,effect,nb,lib,pred,block,k,threads,boot,base,seed,symbolize,normalize,progressbar),varname))
+  return(.bind_sc(RcppSGC4Lattice(cause,effect,nb,lib,pred,block,k,threads,boot,base,seed,TRUE,normalize,progressbar),varname))
 }
 
 .sgc_spatraster_method = \(data, cause, effect, k, block = 3, boot = 399, seed = 42, base = 2, lib = NULL, pred = NULL,
-                           threads = detectThreads(), symbolize = TRUE, normalize = FALSE, progressbar = FALSE){
+                           threads = detectThreads(), trend.rm = TRUE, normalize = FALSE, progressbar = FALSE){
   varname = .check_character(cause, effect)
-  cause = .uni_grid(data,cause,FALSE)
-  effect = .uni_grid(data,effect,FALSE)
+  cause = .uni_grid(data,cause,trend.rm)
+  effect = .uni_grid(data,effect,trend.rm)
   block = matrix(RcppDivideGrid(effect,block),ncol = 1)
   if (is.null(lib)) lib = which(!(is.na(cause) | is.na(effect)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
-  return(.bind_sc(RcppSGC4Grid(cause,effect,lib,pred,block,k,threads,boot,base,seed,symbolize,normalize,progressbar),varname))
+  return(.bind_sc(RcppSGC4Grid(cause,effect,lib,pred,block,k,threads,boot,base,seed,TRUE,normalize,progressbar),varname))
 }
 
 #' spatial granger causality test
@@ -37,7 +37,7 @@ methods::setGeneric("sgc", function(data, ...) standardGeneric("sgc"))
 #' @param pred (optional) Predictions indices.
 #' @param nb (optional) The neighbours list.
 #' @param threads (optional) Number of threads.
-#' @param symbolize (optional) Whether to apply the symbolic map process.
+#' @param trend.rm (optional) Whether to remove the linear trend.
 #' @param normalize (optional) Whether to normalize the result.
 #' @param progressbar (optional) Whether to show the progress bar.
 #'

--- a/man/sgc.Rd
+++ b/man/sgc.Rd
@@ -19,7 +19,7 @@
   pred = NULL,
   nb = NULL,
   threads = detectThreads(),
-  symbolize = TRUE,
+  trend.rm = TRUE,
   normalize = FALSE,
   progressbar = FALSE
 )
@@ -36,7 +36,7 @@
   lib = NULL,
   pred = NULL,
   threads = detectThreads(),
-  symbolize = TRUE,
+  trend.rm = TRUE,
   normalize = FALSE,
   progressbar = FALSE
 )
@@ -66,7 +66,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{symbolize}{(optional) Whether to apply the symbolic map process.}
+\item{trend.rm}{(optional) Whether to remove the linear trend.}
 
 \item{normalize}{(optional) Whether to normalize the result.}
 


### PR DESCRIPTION
This PR modifies the S4 generic `sgc()` interface by:

- Removing the `symbolize` parameter

- Adding a new parameter `trend.rm` to support detrending options

The change ensures alignment with revised modeling assumptions and clarifies the intended preprocessing behavior.

Downstream method signatures and documentation have been updated accordingly.