### PR TITLE
add confidence interval plotting option to S3 methods for gccm and other cross mapping results

### DIFF
--- a/R/formatoutput.R
+++ b/R/formatoutput.R
@@ -87,6 +87,7 @@ print.sc_res = \(x,...){
 plot.ccm_res = \(x, family = "serif",
                  legend_texts = NULL,
                  legend_cols = c("#608dbe","#ed795b"),
+                 draw_ci = FALSE, ci_alpha = 0.2,
                  xbreaks = NULL, xlimits = NULL,
                  ybreaks = seq(0, 1, by = 0.1),
                  ylimits = c(-0.05, 1), ...){
@@ -101,16 +102,32 @@ plot.ccm_res = \(x, family = "serif",
   legend_cols = .check_inputelementnum(legend_cols,2)
   names(legend_cols) = c("x xmap y","y xmap x")
 
+  ci_alpha = .check_inputelementnum(ci_alpha,2)
+
   fig1 = ggplot2::ggplot(data = resdf,
                          ggplot2::aes(x = libsizes)) +
     ggplot2::geom_line(ggplot2::aes(y = y_xmap_x_mean,
                                     color = "y xmap x"),
                        lwd = 1.25)
 
+  if (draw_ci) {
+    fig1 = fig1 +
+      ggplot2::geom_ribbon(ggplot2::aes(ymin = y_xmap_x_lower,
+                                        ymax = y_xmap_x_upper),
+                           alpha = ci_alpha[2], fill = legend_cols[2])
+  }
+
   if (bidirectional){
     fig1 = fig1 + ggplot2::geom_line(ggplot2::aes(y = x_xmap_y_mean,
                                                   color = "x xmap y"),
                                      lwd = 1.25)
+
+    if (draw_ci) {
+      fig1 = fig1 +
+        ggplot2::geom_ribbon(ggplot2::aes(ymin = x_xmap_y_lower,
+                                          ymax = x_xmap_y_upper),
+                             alpha = ci_alpha[1], fill = legend_cols[1])
+    }
   }
 
   fig1 = fig1 +


### PR DESCRIPTION
S3 plotting methods for `gccm()` and related cross mapping functions now support an option to add confidence interval ribbons.
