### PR TITLE
Add Spearman and Kendall correlation functions with NA handling

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -261,6 +261,14 @@ RcppPearsonCor <- function(y, y_hat, NA_rm = FALSE) {
     .Call(`_spEDM_RcppPearsonCor`, y, y_hat, NA_rm)
 }
 
+RcppSpearmanCor <- function(y, y_hat, NA_rm = FALSE) {
+    .Call(`_spEDM_RcppSpearmanCor`, y, y_hat, NA_rm)
+}
+
+RcppKendallCor <- function(y, y_hat, NA_rm = FALSE) {
+    .Call(`_spEDM_RcppKendallCor`, y, y_hat, NA_rm)
+}
+
 RcppPartialCor <- function(y, y_hat, controls, NA_rm = FALSE, linear = FALSE) {
     .Call(`_spEDM_RcppPartialCor`, y, y_hat, controls, NA_rm, linear)
 }

--- a/src/CppStats.h
+++ b/src/CppStats.h
@@ -71,6 +71,14 @@ double PearsonCor(const std::vector<double>& y,
                   const std::vector<double>& y_hat,
                   bool NA_rm = false);
 
+double SpearmanCor(const std::vector<double>& y,
+                   const std::vector<double>& y_hat,
+                   bool NA_rm = false);
+
+double KendallCor(const std::vector<double>& y,
+                  const std::vector<double>& y_hat,
+                  bool NA_rm = false);
+
 double PartialCor(const std::vector<double>& y,
                   const std::vector<double>& y_hat,
                   const std::vector<std::vector<double>>& controls,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -996,6 +996,32 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// RcppSpearmanCor
+double RcppSpearmanCor(const Rcpp::NumericVector& y, const Rcpp::NumericVector& y_hat, bool NA_rm);
+RcppExport SEXP _spEDM_RcppSpearmanCor(SEXP ySEXP, SEXP y_hatSEXP, SEXP NA_rmSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type y_hat(y_hatSEXP);
+    Rcpp::traits::input_parameter< bool >::type NA_rm(NA_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(RcppSpearmanCor(y, y_hat, NA_rm));
+    return rcpp_result_gen;
+END_RCPP
+}
+// RcppKendallCor
+double RcppKendallCor(const Rcpp::NumericVector& y, const Rcpp::NumericVector& y_hat, bool NA_rm);
+RcppExport SEXP _spEDM_RcppKendallCor(SEXP ySEXP, SEXP y_hatSEXP, SEXP NA_rmSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type y_hat(y_hatSEXP);
+    Rcpp::traits::input_parameter< bool >::type NA_rm(NA_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(RcppKendallCor(y, y_hat, NA_rm));
+    return rcpp_result_gen;
+END_RCPP
+}
 // RcppPartialCor
 double RcppPartialCor(const Rcpp::NumericVector& y, const Rcpp::NumericVector& y_hat, const Rcpp::NumericMatrix& controls, bool NA_rm, bool linear);
 RcppExport SEXP _spEDM_RcppPartialCor(SEXP ySEXP, SEXP y_hatSEXP, SEXP controlsSEXP, SEXP NA_rmSEXP, SEXP linearSEXP) {
@@ -1282,6 +1308,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSumNormalize", (DL_FUNC) &_spEDM_RcppSumNormalize, 2},
     {"_spEDM_RcppArithmeticSeq", (DL_FUNC) &_spEDM_RcppArithmeticSeq, 3},
     {"_spEDM_RcppPearsonCor", (DL_FUNC) &_spEDM_RcppPearsonCor, 3},
+    {"_spEDM_RcppSpearmanCor", (DL_FUNC) &_spEDM_RcppSpearmanCor, 3},
+    {"_spEDM_RcppKendallCor", (DL_FUNC) &_spEDM_RcppKendallCor, 3},
     {"_spEDM_RcppPartialCor", (DL_FUNC) &_spEDM_RcppPartialCor, 5},
     {"_spEDM_RcppPartialCorTrivar", (DL_FUNC) &_spEDM_RcppPartialCorTrivar, 5},
     {"_spEDM_RcppCorSignificance", (DL_FUNC) &_spEDM_RcppCorSignificance, 3},

--- a/src/StatsExp.cpp
+++ b/src/StatsExp.cpp
@@ -199,6 +199,30 @@ double RcppPearsonCor(const Rcpp::NumericVector& y,
   return PearsonCor(y_vec, y_hat_vec, NA_rm);
 }
 
+// [[Rcpp::export]]
+double RcppSpearmanCor(const Rcpp::NumericVector& y,
+                       const Rcpp::NumericVector& y_hat,
+                       bool NA_rm = false) {
+  // Convert Rcpp::NumericVector to std::vector<double>
+  std::vector<double> y_vec = Rcpp::as<std::vector<double>>(y);
+  std::vector<double> y_hat_vec = Rcpp::as<std::vector<double>>(y_hat);
+
+  // Call the SpearmanCorfunction
+  return SpearmanCor(y_vec, y_hat_vec, NA_rm);
+}
+
+// [[Rcpp::export]]
+double RcppKendallCor(const Rcpp::NumericVector& y,
+                      const Rcpp::NumericVector& y_hat,
+                      bool NA_rm = false) {
+  // Convert Rcpp::NumericVector to std::vector<double>
+  std::vector<double> y_vec = Rcpp::as<std::vector<double>>(y);
+  std::vector<double> y_hat_vec = Rcpp::as<std::vector<double>>(y_hat);
+
+  // Call the KendallCor function
+  return KendallCor(y_vec, y_hat_vec, NA_rm);
+}
+
 // Rcpp wrapper for PartialCor function
 // [[Rcpp::export]]
 double RcppPartialCor(const Rcpp::NumericVector& y,


### PR DESCRIPTION
### Summary

This PR adds two new functions for non-parametric correlation analysis:

- `SpearmanCor`: Computes Spearman's rank correlation by applying a rank transformation to input vectors and calculating the Pearson correlation of the ranks. Utilizes Armadillo for efficient computation.
- `KendallCor`: Computes Kendall's tau-a coefficient based on pairwise concordance and discordance. Ties are ignored as in the standard tau-a formulation.

### Features

- Consistent interface with existing `PearsonCor` function.
- Optional `NA_rm` parameter for handling missing values.
- Returns `NaN` when no valid pairs are available.
- Ensures output is clamped to [-1, 1] for numerical safety.
