### PR TITLE
refactor: rename `trend.rm` parameter to `detrend` for consistency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Introduce confidence interval ribbon support in plot method for `gccm` results (#550).
 
+### breaking changes
+
+* Users must now use `detrend` instead of `trend.rm` (#559).
+
 ### bug fixes
 
 * Fix bug in plot method for `gccm` results where legend labels did not correctly match the corresponding line colors (#552).

--- a/R/embedded.R
+++ b/R/embedded.R
@@ -1,13 +1,13 @@
 methods::setGeneric("embedded", function(data, ...) standardGeneric("embedded"))
 
-.embedded_sf_method = \(data,target,E = 3,tau = 1,nb = NULL,trend.rm = FALSE){
-  vec = .uni_lattice(data,target,trend.rm)
+.embedded_sf_method = \(data,target,E = 3,tau = 1,nb = NULL,detrend = FALSE){
+  vec = .uni_lattice(data,target,detrend)
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   return(RcppGenLatticeEmbeddings(vec,nb,E,tau))
 }
 
-.embedded_spatraster_method = \(data,target,E = 3,tau = 1,trend.rm = FALSE){
-  mat = .uni_grid(data,target,trend.rm)
+.embedded_spatraster_method = \(data,target,E = 3,tau = 1,detrend = FALSE){
+  mat = .uni_grid(data,target,detrend)
   return(RcppGenGridEmbeddings(mat,E,tau))
 }
 
@@ -18,7 +18,7 @@ methods::setGeneric("embedded", function(data, ...) standardGeneric("embedded"))
 #' @param E (optional) Dimensions of the embedding.
 #' @param tau (optional) Step of spatial lags.
 #' @param nb (optional) The neighbours list.
-#' @param trend.rm (optional) Whether to remove the linear trend.
+#' @param detrend (optional) Whether to remove the linear trend.
 #'
 #' @return A matrix
 #' @export

--- a/R/fnn.R
+++ b/R/fnn.R
@@ -1,8 +1,8 @@
 methods::setGeneric("fnn", function(data, ...) standardGeneric("fnn"))
 
 .fnn_sf_method = \(data, target, lib = NULL, pred = NULL, E = 1:10, tau = 1, nb = NULL,
-                   rt = 10, eps = 2, threads = detectThreads(), trend.rm = TRUE){
-  vec = .uni_lattice(data,target,trend.rm)
+                   rt = 10, eps = 2, threads = detectThreads(), detrend = TRUE){
+  vec = .uni_lattice(data,target,detrend)
   rt = .check_inputelementnum(rt,max(E))
   eps = .check_inputelementnum(eps,max(E))
   if (is.null(lib)) lib = which(!is.na(vec))
@@ -12,8 +12,8 @@ methods::setGeneric("fnn", function(data, ...) standardGeneric("fnn"))
 }
 
 .fnn_spatraster_method = \(data, target, lib = NULL, pred = NULL, E = 1:10, tau = 1,
-                           rt = 10, eps = 2, threads = detectThreads(), trend.rm = TRUE){
-  mat = .uni_grid(data,target,trend.rm)
+                           rt = 10, eps = 2, threads = detectThreads(), detrend = TRUE){
+  mat = .uni_grid(data,target,detrend)
   rt = .check_inputelementnum(rt,max(E))
   eps = .check_inputelementnum(eps,max(E))
   if (is.null(lib)) lib = which(!is.na(mat), arr.ind = TRUE)

--- a/R/gccm.R
+++ b/R/gccm.R
@@ -1,7 +1,7 @@
 methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
 
 .gccm_sf_method = \(data, cause, effect, libsizes, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL,
-                    nb = NULL,threads = detectThreads(),parallel.level = "low",bidirectional = TRUE,trend.rm = TRUE,progressbar = TRUE){
+                    nb = NULL,threads = detectThreads(),parallel.level = "low",bidirectional = TRUE,detrend = TRUE,progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -14,8 +14,8 @@ methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
   data = data[,varname]
   names(data) = .varname
 
-  if (trend.rm){
-    data = .internal_trend_rm(data,.varname,coords)
+  if (detrend){
+    data = .internal_detrend(data,.varname,coords)
   }
   cause = data[,"cause",drop = TRUE]
   effect = data[,"effect",drop = TRUE]
@@ -34,7 +34,7 @@ methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
 }
 
 .gccm_spatraster_method = \(data, cause, effect, libsizes, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL,
-                            threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, trend.rm = TRUE, progressbar = TRUE){
+                            threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = TRUE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -46,8 +46,8 @@ methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
   names(data) = .varname
 
   dtf = terra::as.data.frame(data,xy = TRUE,na.rm = FALSE)
-  if (trend.rm){
-    dtf = .internal_trend_rm(dtf,.varname)
+  if (detrend){
+    dtf = .internal_detrend(dtf,.varname)
   }
   causemat = matrix(dtf[,"cause"],nrow = terra::nrow(data),byrow = TRUE)
   effectmat = matrix(dtf[,"effect"],nrow = terra::nrow(data),byrow = TRUE)
@@ -82,7 +82,7 @@ methods::setGeneric("gccm", function(data, ...) standardGeneric("gccm"))
 #' @param threads (optional) Number of threads.
 #' @param parallel.level (optional) Level of parallelism, `low` or `high`.
 #' @param bidirectional (optional) whether to examine bidirectional causality.
-#' @param trend.rm (optional) Whether to remove the linear trend.
+#' @param detrend (optional) Whether to remove the linear trend.
 #' @param progressbar (optional) whether to show the progress bar.
 #'
 #' @return A list

--- a/R/gcmc.R
+++ b/R/gcmc.R
@@ -2,7 +2,7 @@
 methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
 
 .gcmc_sf_method = \(data, cause, effect, E = 3, tau = 1, k = NULL, r = 0, lib = NULL, pred = NULL, nb = NULL,
-                    threads = detectThreads(), bidirectional = TRUE, trend.rm = TRUE, progressbar = TRUE){
+                    threads = detectThreads(), bidirectional = TRUE, detrend = TRUE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -13,8 +13,8 @@ methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
   data = data[,varname]
   names(data) = .varname
 
-  if (trend.rm){
-    data = .internal_trend_rm(data,.varname,coords)
+  if (detrend){
+    data = .internal_detrend(data,.varname,coords)
   }
   cause = data[,"cause",drop = TRUE]
   effect = data[,"effect",drop = TRUE]
@@ -34,7 +34,7 @@ methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
 }
 
 .gcmc_spatraster_method = \(data, cause, effect, E = 3, tau = 1, k = NULL, r = 0, lib = NULL, pred = NULL,
-                            threads = detectThreads(),bidirectional = TRUE,trend.rm = TRUE,progressbar = TRUE){
+                            threads = detectThreads(),bidirectional = TRUE,detrend = TRUE,progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -43,8 +43,8 @@ methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
   names(data) = .varname
 
   dtf = terra::as.data.frame(data,xy = TRUE,na.rm = FALSE)
-  if (trend.rm){
-    dtf = .internal_trend_rm(dtf,.varname)
+  if (detrend){
+    dtf = .internal_detrend(dtf,.varname)
   }
   causemat = matrix(dtf[,"cause"],nrow = terra::nrow(data),byrow = TRUE)
   effectmat = matrix(dtf[,"effect"],nrow = terra::nrow(data),byrow = TRUE)
@@ -77,7 +77,7 @@ methods::setGeneric("gcmc", function(data, ...) standardGeneric("gcmc"))
 #' @param nb (optional) The neighbours list.
 #' @param threads (optional) Number of threads.
 #' @param bidirectional (optional) whether to examine bidirectional causality.
-#' @param trend.rm (optional) Whether to remove the linear trend.
+#' @param detrend (optional) Whether to remove the linear trend.
 #' @param progressbar (optional) whether to show the progress bar.
 #'
 #' @return A list

--- a/R/multiview.R
+++ b/R/multiview.R
@@ -1,9 +1,9 @@
 methods::setGeneric("multiview", function(data, ...) standardGeneric("multiview"))
 
 .multiview_sf_method = \(data,columns,target,nvar,lib = NULL,pred = NULL,E = 3,tau = 1,k = E+2,
-                         nb = NULL, top = NULL, threads = detectThreads(), trend.rm = TRUE){
-  xmat = .multivar_lattice(data,columns,trend.rm)
-  yvec = .uni_lattice(data,target,trend.rm)
+                         nb = NULL, top = NULL, threads = detectThreads(), detrend = TRUE){
+  xmat = .multivar_lattice(data,columns,detrend)
+  yvec = .uni_lattice(data,target,detrend)
   if (is.null(lib)) lib = .internal_library(cbind(xmat,yvec))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
@@ -13,9 +13,9 @@ methods::setGeneric("multiview", function(data, ...) standardGeneric("multiview"
 }
 
 .multiview_spatraster_method = \(data,columns,target,nvar,lib = NULL,pred = NULL,E = 3,tau = 1,
-                                 k = E+2,top = NULL,threads = detectThreads(),trend.rm = TRUE){
-  xmat = .multivar_grid(data,columns,trend.rm)
-  ymat = .multivar_grid(data,target,trend.rm)
+                                 k = E+2,top = NULL,threads = detectThreads(),detrend = TRUE){
+  xmat = .multivar_grid(data,columns,detrend)
+  ymat = .multivar_grid(data,target,detrend)
   if (is.null(lib)) lib = .internal_library(cbind(xmat,ymat),TRUE)
   if (is.null(pred)) pred = lib
   if (is.null(top)) top = 0

--- a/R/sctest.R
+++ b/R/sctest.R
@@ -1,22 +1,22 @@
 methods::setGeneric("sc.test", function(data, ...) standardGeneric("sc.test"))
 
 .sc_sf_method = \(data, cause, effect, k, block = 3, boot = 399, seed = 42, base = 2, lib = NULL, pred = NULL,
-                  nb = NULL, threads = detectThreads(), trend.rm = TRUE, normalize = FALSE, progressbar = FALSE){
+                  nb = NULL, threads = detectThreads(), detrend = TRUE, normalize = FALSE, progressbar = FALSE){
   varname = .check_character(cause, effect)
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   block = RcppDivideLattice(nb,block)
-  cause = .uni_lattice(data,cause,trend.rm)
-  effect = .uni_lattice(data,effect,trend.rm)
+  cause = .uni_lattice(data,cause,detrend)
+  effect = .uni_lattice(data,effect,detrend)
   if (is.null(lib)) lib = which(!(is.na(cause) | is.na(effect)))
   if (is.null(pred)) pred = lib
   return(.bind_sc(RcppSGC4Lattice(cause,effect,nb,lib,pred,block,k,threads,boot,base,seed,TRUE,normalize,progressbar),varname))
 }
 
 .sc_spatraster_method = \(data, cause, effect, k, block = 3, boot = 399, seed = 42, base = 2, lib = NULL, pred = NULL,
-                          threads = detectThreads(), trend.rm = TRUE, normalize = FALSE, progressbar = FALSE){
+                          threads = detectThreads(), detrend = TRUE, normalize = FALSE, progressbar = FALSE){
   varname = .check_character(cause, effect)
-  cause = .uni_grid(data,cause,trend.rm)
-  effect = .uni_grid(data,effect,trend.rm)
+  cause = .uni_grid(data,cause,detrend)
+  effect = .uni_grid(data,effect,detrend)
   block = matrix(RcppDivideGrid(effect,block),ncol = 1)
   if (is.null(lib)) lib = which(!(is.na(cause) | is.na(effect)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
@@ -37,7 +37,7 @@ methods::setGeneric("sc.test", function(data, ...) standardGeneric("sc.test"))
 #' @param pred (optional) Predictions indices.
 #' @param nb (optional) The neighbours list.
 #' @param threads (optional) Number of threads.
-#' @param trend.rm (optional) Whether to remove the linear trend.
+#' @param detrend (optional) Whether to remove the linear trend.
 #' @param normalize (optional) Whether to normalize the result.
 #' @param progressbar (optional) Whether to show the progress bar.
 #'

--- a/R/simplex.R
+++ b/R/simplex.R
@@ -1,8 +1,8 @@
 methods::setGeneric("simplex", function(data, ...) standardGeneric("simplex"))
 
 .simplex_sf_method = \(data,target,lib = NULL,pred = NULL,E = 1:10,tau = 1,k = E+2,
-                       nb = NULL, threads = detectThreads(), trend.rm = TRUE){
-  vec = .uni_lattice(data,target,trend.rm)
+                       nb = NULL, threads = detectThreads(), detrend = TRUE){
+  vec = .uni_lattice(data,target,detrend)
   if (is.null(lib)) lib = which(!is.na(vec))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
@@ -11,8 +11,8 @@ methods::setGeneric("simplex", function(data, ...) standardGeneric("simplex"))
 }
 
 .simplex_spatraster_method = \(data,target,lib = NULL,pred = NULL,E = 1:10,tau = 1,
-                               k = E+2, threads = detectThreads(), trend.rm = TRUE){
-  mat = .uni_grid(data,target,trend.rm)
+                               k = E+2, threads = detectThreads(), detrend = TRUE){
+  mat = .uni_grid(data,target,detrend)
   if (is.null(lib)) lib = which(!is.na(mat), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
   res = RcppSimplex4Grid(mat,lib,pred,E,k,tau,threads)

--- a/R/smap.R
+++ b/R/smap.R
@@ -3,8 +3,8 @@ methods::setGeneric("smap", function(data, ...) standardGeneric("smap"))
 .smap_sf_method = \(data,target,lib = NULL,pred = NULL,E = 3,tau = 1,k = E+2,
                     theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03,
                               0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8),
-                    nb = NULL, threads = detectThreads(), trend.rm = TRUE){
-  vec = .uni_lattice(data,target,trend.rm)
+                    nb = NULL, threads = detectThreads(), detrend = TRUE){
+  vec = .uni_lattice(data,target,detrend)
   if (is.null(lib)) lib = which(!is.na(vec))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
@@ -15,8 +15,8 @@ methods::setGeneric("smap", function(data, ...) standardGeneric("smap"))
 .smap_spatraster_method = \(data,target,lib = NULL,pred = NULL,E = 3,tau = 1,k = E+2,
                             theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03,
                                       0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8),
-                            threads = detectThreads(), trend.rm = TRUE){
-  mat = .uni_grid(data,target,trend.rm)
+                            threads = detectThreads(), detrend = TRUE){
+  mat = .uni_grid(data,target,detrend)
   if (is.null(lib)) lib = which(!is.na(mat), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
   res = RcppSMap4Grid(mat,lib,pred,theta,E,tau,k,threads)

--- a/R/variable_check_prepare.R
+++ b/R/variable_check_prepare.R
@@ -44,7 +44,7 @@
   return(nb)
 }
 
-.internal_trend_rm = \(data,.varname,coords = NULL){
+.internal_detrend = \(data,.varname,coords = NULL){
   if (is.null(coords)){
     for (i in seq_along(.varname)){
       data[,.varname[i]] = sdsfun::rm_lineartrend(paste0(.varname[i],"~x+y"), data = data)
@@ -64,53 +64,53 @@
   return(nnaindice)
 }
 
-.uni_lattice = \(data,target,trend.rm = FALSE){
+.uni_lattice = \(data,target,detrend = FALSE){
   target = .check_character(target)
   coords = as.data.frame(sdsfun::sf_coordinates(data))
   data = sf::st_drop_geometry(data)
   data = data[,target,drop = FALSE]
   names(data) = "target"
-  if (trend.rm){
-    data = .internal_trend_rm(data,"target",coords)
+  if (detrend){
+    data = .internal_detrend(data,"target",coords)
   }
   res = data[,"target",drop = TRUE]
   return(res)
 }
 
-.uni_grid = \(data,target,trend.rm = FALSE){
+.uni_grid = \(data,target,detrend = FALSE){
   target = .check_character(target)
   data = data[[target]]
   names(data) = "target"
   dtf = terra::as.data.frame(data,xy = TRUE,na.rm = FALSE)
-  if (trend.rm){
-    dtf = .internal_trend_rm(dtf,"target")
+  if (detrend){
+    dtf = .internal_detrend(dtf,"target")
   }
   res = matrix(dtf[,"target"],nrow = terra::nrow(data),byrow = TRUE)
   return(res)
 }
 
-.multivar_lattice = \(data,columns,trend.rm = FALSE){
+.multivar_lattice = \(data,columns,detrend = FALSE){
   columns = .check_character(columns)
   coords = as.data.frame(sdsfun::sf_coordinates(data))
   data = sf::st_drop_geometry(data)
   data = data[,columns,drop = FALSE]
   .varname = paste0("z",seq_along(columns))
   names(data) = .varname
-  if (trend.rm){
-    data = .internal_trend_rm(data,.varname,coords)
+  if (detrend){
+    data = .internal_detrend(data,.varname,coords)
   }
   res = as.matrix(data[,.varname,drop = FALSE])
   return(res)
 }
 
-.multivar_grid = \(data,columns,trend.rm = FALSE){
+.multivar_grid = \(data,columns,detrend = FALSE){
   columns = .check_character(columns)
   data = data[[columns]]
   .varname = paste0("z",seq_along(columns))
   names(data) = .varname
   dtf = terra::as.data.frame(data,xy = TRUE,na.rm = FALSE)
-  if (trend.rm){
-    dtf = .internal_trend_rm(dtf,.varname)
+  if (detrend){
+    dtf = .internal_detrend(dtf,.varname)
   }
   res = as.matrix(dtf[,.varname,drop = FALSE])
   return(res)

--- a/man/embedded.Rd
+++ b/man/embedded.Rd
@@ -6,9 +6,9 @@
 \alias{embedded,SpatRaster-method}
 \title{embedding spatial cross sectional data}
 \usage{
-\S4method{embedded}{sf}(data, target, E = 3, tau = 1, nb = NULL, trend.rm = FALSE)
+\S4method{embedded}{sf}(data, target, E = 3, tau = 1, nb = NULL, detrend = FALSE)
 
-\S4method{embedded}{SpatRaster}(data, target, E = 3, tau = 1, trend.rm = FALSE)
+\S4method{embedded}{SpatRaster}(data, target, E = 3, tau = 1, detrend = FALSE)
 }
 \arguments{
 \item{data}{The observation data.}
@@ -21,7 +21,7 @@
 
 \item{nb}{(optional) The neighbours list.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 }
 \value{
 A matrix

--- a/man/fnn.Rd
+++ b/man/fnn.Rd
@@ -17,7 +17,7 @@
   rt = 10,
   eps = 2,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 
 \S4method{fnn}{SpatRaster}(
@@ -30,7 +30,7 @@
   rt = 10,
   eps = 2,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 }
 \arguments{
@@ -54,7 +54,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 }
 \value{
 A vector

--- a/man/gccm.Rd
+++ b/man/gccm.Rd
@@ -22,7 +22,7 @@
   threads = detectThreads(),
   parallel.level = "low",
   bidirectional = TRUE,
-  trend.rm = TRUE,
+  detrend = TRUE,
   progressbar = TRUE
 )
 
@@ -41,7 +41,7 @@
   threads = detectThreads(),
   parallel.level = "low",
   bidirectional = TRUE,
-  trend.rm = TRUE,
+  detrend = TRUE,
   progressbar = TRUE
 )
 }
@@ -76,7 +76,7 @@
 
 \item{bidirectional}{(optional) whether to examine bidirectional causality.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 
 \item{progressbar}{(optional) whether to show the progress bar.}
 }

--- a/man/gcmc.Rd
+++ b/man/gcmc.Rd
@@ -19,7 +19,7 @@
   nb = NULL,
   threads = detectThreads(),
   bidirectional = TRUE,
-  trend.rm = TRUE,
+  detrend = TRUE,
   progressbar = TRUE
 )
 
@@ -35,7 +35,7 @@
   pred = NULL,
   threads = detectThreads(),
   bidirectional = TRUE,
-  trend.rm = TRUE,
+  detrend = TRUE,
   progressbar = TRUE
 )
 }
@@ -64,7 +64,7 @@
 
 \item{bidirectional}{(optional) whether to examine bidirectional causality.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 
 \item{progressbar}{(optional) whether to show the progress bar.}
 }

--- a/man/multiview.Rd
+++ b/man/multiview.Rd
@@ -19,7 +19,7 @@
   nb = NULL,
   top = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 
 \S4method{multiview}{SpatRaster}(
@@ -34,7 +34,7 @@
   k = E + 2,
   top = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 }
 \arguments{
@@ -62,7 +62,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 }
 \value{
 A vector (when input is sf object) or matrix

--- a/man/sc.test.Rd
+++ b/man/sc.test.Rd
@@ -19,7 +19,7 @@
   pred = NULL,
   nb = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE,
+  detrend = TRUE,
   normalize = FALSE,
   progressbar = FALSE
 )
@@ -36,7 +36,7 @@
   lib = NULL,
   pred = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE,
+  detrend = TRUE,
   normalize = FALSE,
   progressbar = FALSE
 )
@@ -66,7 +66,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 
 \item{normalize}{(optional) Whether to normalize the result.}
 

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -16,7 +16,7 @@
   k = E + 2,
   nb = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 
 \S4method{simplex}{SpatRaster}(
@@ -28,7 +28,7 @@
   tau = 1,
   k = E + 2,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 }
 \arguments{
@@ -50,7 +50,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 }
 \value{
 A list

--- a/man/smap.Rd
+++ b/man/smap.Rd
@@ -18,7 +18,7 @@
     4, 6, 8),
   nb = NULL,
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 
 \S4method{smap}{SpatRaster}(
@@ -32,7 +32,7 @@
   theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3,
     4, 6, 8),
   threads = detectThreads(),
-  trend.rm = TRUE
+  detrend = TRUE
 )
 }
 \arguments{
@@ -56,7 +56,7 @@
 
 \item{threads}{(optional) Number of threads.}
 
-\item{trend.rm}{(optional) Whether to remove the linear trend.}
+\item{detrend}{(optional) Whether to remove the linear trend.}
 }
 \value{
 A list


### PR DESCRIPTION
BREAKING CHANGE: Users must now use `detrend` instead of `trend.rm`!