### PR TITLE
rebuild vignettes

### DIFF
--- a/vignettes/GCCM.Rmd.orig
+++ b/vignettes/GCCM.Rmd.orig
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Model principles
+## Methodological Background
 
 Let $Y = \{y_i\}$ and $X = \{x_i\}$ be the two spatial cross sectional variable, where $i = 1, 2, \dots, n$ denotes spatial units (e.g., regions or grid cells), the shadow manifolds of $X$ can be constructed using the different spatial lag values of all spatial units:
 

--- a/vignettes/GCMC.Rmd.orig
+++ b/vignettes/GCMC.Rmd.orig
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 
 The `GCMC` algorithm provided in this package is a research method currently **under peer review in the *International Journal of Geographical Information Science (IJGIS)* **. We provide early access to its implementation and a detailed vignette for reproducibility. Users should note that **methodological details may evolve** before final publication.
 
-## Model principles
+## Methodological Background
 
 To measure causal associations in spatial cross-sectional data, GCMC (Geographical Convergent Cross Mapping) employs a three-stage procedure:
 

--- a/vignettes/SCT.Rmd.orig
+++ b/vignettes/SCT.Rmd.orig
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Model principles
+## Methodological Background
 
 Let us begin by defining two spatial cross-sectional series $\{x_s\}_{s \in S}$ and $\{y_s\}_{s \in S}$, where $S$ represents the study area.
 

--- a/vignettes/SLM.Rmd.orig
+++ b/vignettes/SLM.Rmd.orig
@@ -17,6 +17,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Method principles
+## Methodological Background
 
 ## Usage examples

--- a/vignettes/SSR.Rmd.orig
+++ b/vignettes/SSR.Rmd.orig
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Spatial State Space Reconstruction (S-SSR)
+## Methodological Background
 
 Takens theory proves that for a dynamical system $\phi$, if its trajectory converges to an attractor manifold $M$—a bounded and invariant set of states—then there exists a smooth mapping between the system $\phi$ and its attractor $M$. Consequently, the time series observations of $\phi$ can be used to reconstruct the structure of $M$ through delay embedding.
 


### PR DESCRIPTION
- refine vignette organization: standardize algorithmic description headings as `Methodological Background`.
- rebuild vignettes to synchronize with updated cpp source code.