### PR TITLE
adopt a more robust approach to managing `S4` generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ### enhancements
 
+* Prevent duplicate generic registrations and simplify method definitions (#627).
+
 * Unify parameter descriptions to lowercase (#570).
 
 * Introduce confidence interval ribbon support in plot method for `gccm` results (#550).

--- a/R/Agenerics.R
+++ b/R/Agenerics.R
@@ -1,11 +1,13 @@
 register_generic = \(name, def = NULL) {
-  if (is.null(def)) {
-    def = eval(bquote(function(data, ...) standardGeneric(.(name))))
+  if (!methods::isGeneric(name)){
+    if (is.null(def)) {
+      def = eval(bquote(function(data, ...) standardGeneric(.(name))))
+    }
+    methods::setGeneric(name, def)
   }
-  methods::setGeneric(name, def)
 }
 
 for (gen in c("embedded", "fnn", "slm", "simplex", "smap",
-              "multiview", "gccm", "gcmc", "sc.test")) {
+              "multiview", "sc.test", "gccm", "gcmc", "scpcm")) {
   register_generic(gen)
 }


### PR DESCRIPTION
This PR prevents duplicate generic registration errors and simplifies method definitions.

