### PR TITLE
compute AUC using trapezoidal rule, retain DeLong method for p-value and CI

### DIFF
--- a/src/CppStats.cpp
+++ b/src/CppStats.cpp
@@ -900,84 +900,82 @@ std::vector<double> CppDeLongAUCConfidence(const std::vector<double>& cases,
 }
 
 /**
- * Computes the AUC (theta), p-value, and confidence interval using the DeLong method.
+ * Computes the AUC (via area method), p-value, and confidence interval using the DeLong method.
  *
  * @param cases A vector of scores for the cases (positive class).
- * @param direction A string indicating the direction of comparison (">" for greater, "<" for less).
+ * @param direction A string indicating the direction of comparison (">" or "<").
  * @param level The confidence level, default is 0.05.
- * @param num_samples Number of effective sample size
+ * @param num_samples Number of effective sample size for the control group.
  *
  * @return A vector of four elements:
- *   - theta: The computed AUC value.
- *   - p_value: The p-value for testing the null hypothesis that AUC = 0.5.
- *   - ci_lower: The lower bound of the confidence interval.
- *   - ci_upper: The upper bound of the confidence interval.
+ *   - area_auc: AUC computed by trapezoidal rule (area method).
+ *   - p_value: The p-value testing H0: AUC = 0.5 (via DeLong).
+ *   - ci_upper: Upper bound of 100*(1-level)% confidence interval (via DeLong).
+ *   - ci_lower: Lower bound of 100*(1-level)% confidence interval (via DeLong).
  */
 std::vector<double> CppCMCTest(const std::vector<double>& cases,
                                const std::string& direction,
                                double level = 0.05,
                                size_t num_samples = 0) {
-  size_t m = cases.size(), n = cases.size();  // Both m and n are set to cases.size()
+  size_t m = cases.size();
+  if (m <= 1) {
+    return {std::numeric_limits<double>::quiet_NaN(), 1.0,
+            std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()};
+  }
 
-  if (num_samples == 0){
+  if (num_samples == 0) {
     num_samples = m;
   }
 
-  std::vector<double> controls;
-  // for (size_t i = 0; i < cases.size(); ++i) {
-  //   controls.push_back(static_cast<double>(i) / num_samples);
-  // }
-  for (size_t i = 0; i < cases.size(); ++i) {
-    controls.push_back(0.5 * static_cast<double>(i + 1) / num_samples); // theoretical AUC for H0 = 0.5
+  // === AUC via area under curve (trapezoidal rule) ===
+  std::vector<double> x(m);
+  for (size_t i = 0; i < m; ++i) {
+    x[i] = static_cast<double>(i) / (m - 1);  // normalized x-axis [0,1]
   }
 
-  // Compute DeLong placements
+  // Compute area AUC using trapezoidal integration
+  double area_auc = 0.0;
+  for (size_t i = 1; i < m; ++i) {
+    area_auc += 0.5 * (cases[i] + cases[i - 1]) * (x[i] - x[i - 1]);
+  }
+
+  // === DeLong p-value and CI ===
+  std::vector<double> controls;
+  for (size_t i = 0; i < m; ++i) {
+    controls.push_back(0.5 * static_cast<double>(i + 1) / num_samples);
+  }
+
+  // DeLong placements
   DeLongPlacementsRes ret = CppDeLongPlacements(cases, controls, direction);
   double theta = ret.theta;
   std::vector<double> X = ret.X;
   std::vector<double> Y = ret.Y;
 
-  // If there are too few cases or controls, return default values
-  if (m <= 1 || n <= 1) {
-    return {theta, 1.0, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()}; // Default values for invalid input
+  if (X.size() <= 1 || Y.size() <= 1) {
+    return {area_auc, 1.0, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
   }
 
-  // Compute variances SX and SY
+  // Compute variances
   double SX = 0.0, SY = 0.0;
   for (size_t i = 0; i < m; ++i) {
     SX += (X[i] - theta) * (X[i] - theta);
-  }
-  SX /= (m - 1);
-
-  for (size_t i = 0; i < n; ++i) {
     SY += (Y[i] - theta) * (Y[i] - theta);
   }
-  SY /= (n - 1);
+  SX /= (m - 1);
+  SY /= (m - 1);  // controls.size() == cases.size()
 
-  // Compute the overall variance S
-  double S = SX / m + SY / n;
-
-  // Compute the Z-score for the p-value
+  double S = SX / m + SY / m;
   double z = (theta - 0.5) / std::sqrt(S);
-
-  // Compute the two-tailed p-value (AUC ≠ 0.5)
   double p_value = 2 * R::pnorm(-std::abs(z), 0.0, 1.0, true, false);
 
-  // // Compute the one-sided test (right-tailed) p-value (AUC > 0.5)
-  // // double p_value = R::pnorm(z, 0.0, 1.0, true, false);
-  // // Set theta to negative when sample size is small to mitigate sample size effect`
-  // double p_value = R::pnorm(-std::abs(z), 0.0, 1.0, true, false);
-
-  // Compute the confidence interval using R::qnorm
+  // Confidence interval using DeLong variance
   double ci_lower = R::qnorm(level / 2, theta, std::sqrt(S), true, false);
   double ci_upper = R::qnorm(1 - level / 2, theta, std::sqrt(S), true, false);
-
-  // Ensure the confidence interval is within [0, 1]
   ci_lower = std::max(0.0, ci_lower);
   ci_upper = std::min(1.0, ci_upper);
 
-  // Return the results as a four-element vector
-  return {theta, p_value, ci_upper, ci_lower};
+  return {area_auc, p_value, ci_upper, ci_lower};
 }
 
 // Function to compute distance between two vectors:

--- a/src/CppStats.cpp
+++ b/src/CppStats.cpp
@@ -927,8 +927,8 @@ std::vector<double> CppCMCTest(const std::vector<double>& cases,
   // for (size_t i = 0; i < cases.size(); ++i) {
   //   controls.push_back(static_cast<double>(i) / num_samples);
   // }
-  for (size_t i = 1; i <= cases.size(); ++i) {
-    controls.push_back(static_cast<double>(i) / num_samples);
+  for (size_t i = 0; i < cases.size(); ++i) {
+    controls.push_back(0.5 * static_cast<double>(i + 1) / num_samples); // theoretical AUC for H0 = 0.5
   }
 
   // Compute DeLong placements


### PR DESCRIPTION
- Changed AUC calculation in `CppCMCTest` to use area under curve (trapezoidal integration)
- Retained DeLong placement method to compute p-value and confidence interval
- Ensures consistency with Python-style AUC (e.g., sklearn.metrics.auc) for causal strength
- DeLong still used to test statistical significance of `AUC > 0.5` under H0
- No impact on RNG state; R::qnorm and R::pnorm remain deterministic
