### PR TITLE
enhance mutual cross mapping `s3` plot method by adding p-value annotation for max library size in legend

### DIFF
--- a/R/formatoutput.R
+++ b/R/formatoutput.R
@@ -109,7 +109,7 @@ plot.ccm_res = \(x, family = "serif",
         dplyr::select(y_xmap_x_sig,x_xmap_y_sig) |>
         unlist() |>
         round(3)
-      legend_texts = paste0(legend_texts,pval)
+      legend_texts = paste0(legend_texts,", P = ",pval)
     }
   }
   legend_texts = .check_inputelementnum(legend_texts,2)


### PR DESCRIPTION
This update improves the interpretability of cross mapping results by explicitly showing the statistical significance (p-value) associated with the largest library size used, directly within the plot legend.