### PR TITLE
harden: transient index handling

### DIFF
--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -199,7 +199,7 @@
   if (is.null(transient)) {
     res = lapply(mat_list, \(.x) apply(.x,1,mean,na.rm = TRUE))
   } else {
-    res = lapply(mat_list, \(.x) apply(.x[,-abs(transient),drop = FALSE],1,mean,na.rm = TRUE))
+    res = lapply(mat_list, \(.x) apply(.x[,-unique(abs(transient)),drop = FALSE],1,mean,na.rm = TRUE))
   }
 
   indices = NULL


### PR DESCRIPTION
Refines the way transient indices are removed by replacing `.x[,-abs(transient),drop = FALSE]` with `.x[,-unique(abs(transient)),drop = FALSE]`, improving robustness against duplicate values in `transient`.
