### PR TITLE
include distance metric and averaging options to simplex projection prediction

### DIFF
--- a/src/SimplexProjection.cpp
+++ b/src/SimplexProjection.cpp
@@ -9,18 +9,26 @@
 /*
  * Perform simplex projection prediction using state-space reconstruction.
  *
- * Given reconstructed vectors and a target spatial cross sections, this function
- * predicts target values at specified prediction indices by weighting nearest
- * neighbors in the library set. Distances involving NaN components are excluded
- * to ensure numerical stability.
+ * Given reconstructed state-space vectors and corresponding target values,
+ * this function predicts target values at specified prediction indices by
+ * weighting nearest neighbors from a given library set.
+ *
+ * Distance calculations exclude NaN components to ensure numerical stability.
+ * Supports two distance metrics and optional averaging of distance by the
+ * number of valid vector components.
+ *
+ * Supported distance metrics:
+ *   dist_metric = 1: L1 (Manhattan) distance
+ *   dist_metric = 2: L2 (Euclidean) distance
  *
  * Parameters:
- *   vectors     - A 2D vector representing reconstructed state-space vectors.
- *                 Each element vectors[i] is a vector/state at spatial unit i.
- *   target      - The spatial cross sections values corresponding to each vector.
- *   lib_indices - Indices specifying which states to use as library (neighbors).
- *   pred_indices- Indices specifying which states to make predictions for.
- *   num_neighbors - Number of nearest neighbors to consider in prediction.
+ *   vectors        - 2D vector of reconstructed state-space vectors; vectors[i] corresponds to spatial unit i.
+ *   target         - Target values for each spatial unit.
+ *   lib_indices    - Indices specifying states used as the library (neighbors).
+ *   pred_indices   - Indices specifying states to predict.
+ *   num_neighbors  - Number of nearest neighbors considered for prediction.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A vector<double> of predicted target values aligned with input target size.
@@ -31,7 +39,9 @@ std::vector<double> SimplexProjectionPrediction(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 ) {
   size_t N = target.size();
   std::vector<double> pred(N, std::numeric_limits<double>::quiet_NaN());
@@ -58,12 +68,22 @@ std::vector<double> SimplexProjectionPrediction(
       double count = 0.0;
       for (size_t j = 0; j < vectors[p].size(); ++j) {
         if (!std::isnan(vectors[i][j]) && !std::isnan(vectors[p][j])) {
-          sum_sq += std::pow(vectors[i][j] - vectors[p][j], 2);
+          double diff = vectors[i][j] - vectors[p][j]; 
+          // sum_sq += (dist_metric == 1) ? std::abs(diff) : diff * diff;
+          if (dist_metric == 1) {
+            sum_sq += std::abs(diff); // L1
+          } else {
+            sum_sq += diff * diff;    // L2
+          }
           count += 1.0;
         }
       }
       if (count > 0) {
-        distances.push_back(std::sqrt(sum_sq / count));
+        if (dist_metric == 1) {  // L1
+          distances.push_back(sum_sq / (dist_average ? count : 1.0));       
+        } else {                 // L2
+          distances.push_back(std::sqrt(sum_sq / (dist_average ? count : 1.0))); 
+        }
         valid_libs.push_back(i);
       }
     }
@@ -132,6 +152,8 @@ std::vector<double> SimplexProjectionPrediction(
  *   - lib_indices: Vector of indices indicating which states to include when searching for neighbors.
  *   - pred_indices: Vector of indices indicating which states to use for prediction.
  *   - num_neighbors: Number of neighbors to use for simplex projection.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A double representing the Pearson correlation coefficient (rho) between the predicted and actual target values.
@@ -141,11 +163,13 @@ double SimplexProjection(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 ) {
   double rho = std::numeric_limits<double>::quiet_NaN();
 
-  std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors);
+  std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors, dist_metric, dist_average);
 
   if (checkOneDimVectorNotNanNum(target_pred) >= 3) {
     rho = PearsonCor(target_pred, target, true);
@@ -162,6 +186,8 @@ double SimplexProjection(
  *   - lib_indices: Vector of indices indicating which states to include when searching for neighbors.
  *   - pred_indices: Vector of indices indicating which states to predict from.
  *   - num_neighbors: Number of neighbors to use for simplex projection.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A vector<double> containing:
@@ -174,13 +200,15 @@ std::vector<double> SimplexBehavior(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 ) {
   double pearson = std::numeric_limits<double>::quiet_NaN();
   double mae = std::numeric_limits<double>::quiet_NaN();
   double rmse = std::numeric_limits<double>::quiet_NaN();
 
-  std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors);
+  std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors, dist_metric, dist_average);
 
   if (checkOneDimVectorNotNanNum(target_pred) >= 3) {
     pearson = PearsonCor(target_pred, target, true);

--- a/src/SimplexProjection.h
+++ b/src/SimplexProjection.h
@@ -12,18 +12,26 @@
 /*
  * Perform simplex projection prediction using state-space reconstruction.
  *
- * Given reconstructed vectors and a target spatial cross sections, this function
- * predicts target values at specified prediction indices by weighting nearest
- * neighbors in the library set. Distances involving NaN components are excluded
- * to ensure numerical stability.
+ * Given reconstructed state-space vectors and corresponding target values,
+ * this function predicts target values at specified prediction indices by
+ * weighting nearest neighbors from a given library set.
+ *
+ * Distance calculations exclude NaN components to ensure numerical stability.
+ * Supports two distance metrics and optional averaging of distance by the
+ * number of valid vector components.
+ *
+ * Supported distance metrics:
+ *   dist_metric = 1: L1 (Manhattan) distance
+ *   dist_metric = 2: L2 (Euclidean) distance
  *
  * Parameters:
- *   vectors     - A 2D vector representing reconstructed state-space vectors.
- *                 Each element vectors[i] is a vector/state at spatial unit i.
- *   target      - The spatial cross sections values corresponding to each vector.
- *   lib_indices - Indices specifying which states to use as library (neighbors).
- *   pred_indices- Indices specifying which states to make predictions for.
- *   num_neighbors - Number of nearest neighbors to consider in prediction.
+ *   vectors        - 2D vector of reconstructed state-space vectors; vectors[i] corresponds to spatial unit i.
+ *   target         - Target values for each spatial unit.
+ *   lib_indices    - Indices specifying states used as the library (neighbors).
+ *   pred_indices   - Indices specifying states to predict.
+ *   num_neighbors  - Number of nearest neighbors considered for prediction.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A vector<double> of predicted target values aligned with input target size.
@@ -34,7 +42,9 @@ std::vector<double> SimplexProjectionPrediction(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 /*
@@ -46,6 +56,8 @@ std::vector<double> SimplexProjectionPrediction(
  *   - lib_indices: Vector of indices indicating which states to include when searching for neighbors.
  *   - pred_indices: Vector of indices indicating which states to use for prediction.
  *   - num_neighbors: Number of neighbors to use for simplex projection.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A double representing the Pearson correlation coefficient (rho) between the predicted and actual target values.
@@ -55,7 +67,9 @@ double SimplexProjection(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 /*
@@ -67,6 +81,8 @@ double SimplexProjection(
  *   - lib_indices: Vector of indices indicating which states to include when searching for neighbors.
  *   - pred_indices: Vector of indices indicating which states to predict from.
  *   - num_neighbors: Number of neighbors to use for simplex projection.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
  *
  * Returns:
  *   A vector<double> containing:
@@ -79,7 +95,9 @@ std::vector<double> SimplexBehavior(
     const std::vector<double>& target,
     const std::vector<int>& lib_indices,
     const std::vector<int>& pred_indices,
-    int num_neighbors
+    int num_neighbors,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 #endif // SimplexProjection_H


### PR DESCRIPTION
### Summary
This PR enhances the simplex projection prediction function by adding two new parameters:

- `dist_metric`: allows choosing between Manhattan (L1) and Euclidean (L2) distance metrics.
- `dist_average`: a boolean flag to control whether distances are averaged by the count of valid vector components.

### Motivation
Previously, the function only supported RMSD and a fixed averaging approach. This update provides greater flexibility for users to select their preferred distance measure and normalization method for neighbor weighting, improving adaptability to different datasets and use cases.

### Changes
- Added `dist_metric` parameter with default set to 2 (Euclidean).
- Added `dist_average` parameter with default `true`.
- Updated distance calculation loops to handle these new options.
- Updated documentation comments to reflect these changes.

### Impact
No breaking changes; defaults maintain backward compatibility. Users can now explicitly control distance calculations to better fit their analysis needs.
