### PR TITLE
synchronize updating the cross mapping prediction behavior

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,12 +33,12 @@ RcppConditionalEntropy_Disc <- function(mat, target_columns, conditional_columns
     .Call(`_spEDM_RcppConditionalEntropy_Disc`, mat, target_columns, conditional_columns, base, NA_rm)
 }
 
-RcppSimplexForecast <- function(embedding, target, lib, pred, num_neighbors = 4L) {
-    .Call(`_spEDM_RcppSimplexForecast`, embedding, target, lib, pred, num_neighbors)
+RcppSimplexForecast <- function(embedding, target, lib, pred, num_neighbors = 4L, dist_metric = 2L, dist_average = TRUE) {
+    .Call(`_spEDM_RcppSimplexForecast`, embedding, target, lib, pred, num_neighbors, dist_metric, dist_average)
 }
 
-RcppSMapForecast <- function(embedding, target, lib, pred, num_neighbors = 4L, theta = 1.0) {
-    .Call(`_spEDM_RcppSMapForecast`, embedding, target, lib, pred, num_neighbors, theta)
+RcppSMapForecast <- function(embedding, target, lib, pred, num_neighbors = 4L, theta = 1.0, dist_metric = 2L, dist_average = TRUE) {
+    .Call(`_spEDM_RcppSMapForecast`, embedding, target, lib, pred, num_neighbors, theta, dist_metric, dist_average)
 }
 
 RcppIntersectionCardinality <- function(embedding_x, embedding_y, lib, pred, num_neighbors = 4L, n_excluded = 0L, threads = 8L, parallel_level = 0L) {
@@ -89,12 +89,12 @@ RcppFNN4Grid <- function(mat, rt, eps, lib, pred, E, tau = 1L, threads = 8L, par
     .Call(`_spEDM_RcppFNN4Grid`, mat, rt, eps, lib, pred, E, tau, threads, parallel_level)
 }
 
-RcppSimplex4Grid <- function(source, target, lib, pred, E, b, tau = 1L, threads = 8L) {
-    .Call(`_spEDM_RcppSimplex4Grid`, source, target, lib, pred, E, b, tau, threads)
+RcppSimplex4Grid <- function(source, target, lib, pred, E, b, tau = 1L, style = 1L, dist_metric = 2L, dist_average = TRUE, threads = 8L) {
+    .Call(`_spEDM_RcppSimplex4Grid`, source, target, lib, pred, E, b, tau, style, dist_metric, dist_average, threads)
 }
 
-RcppSMap4Grid <- function(source, target, lib, pred, theta, E = 3L, tau = 1L, b = 5L, threads = 8L) {
-    .Call(`_spEDM_RcppSMap4Grid`, source, target, lib, pred, theta, E, tau, b, threads)
+RcppSMap4Grid <- function(source, target, lib, pred, theta, E = 3L, tau = 1L, b = 5L, style = 1L, dist_metric = 2L, dist_average = TRUE, threads = 8L) {
+    .Call(`_spEDM_RcppSMap4Grid`, source, target, lib, pred, theta, E, tau, b, style, dist_metric, dist_average, threads)
 }
 
 RcppMultiView4Grid <- function(xMatrix, yMatrix, lib, pred, E = 3L, tau = 1L, b = 5L, top = 5L, nvar = 3L, threads = 8L) {
@@ -185,12 +185,12 @@ RcppFNN4Lattice <- function(vec, nb, rt, eps, lib, pred, E, tau = 1L, threads = 
     .Call(`_spEDM_RcppFNN4Lattice`, vec, nb, rt, eps, lib, pred, E, tau, threads, parallel_level)
 }
 
-RcppSimplex4Lattice <- function(source, target, nb, lib, pred, E, b, tau = 1L, threads = 8L) {
-    .Call(`_spEDM_RcppSimplex4Lattice`, source, target, nb, lib, pred, E, b, tau, threads)
+RcppSimplex4Lattice <- function(source, target, nb, lib, pred, E, b, tau = 1L, style = 1L, dist_metric = 2L, dist_average = TRUE, threads = 8L) {
+    .Call(`_spEDM_RcppSimplex4Lattice`, source, target, nb, lib, pred, E, b, tau, style, dist_metric, dist_average, threads)
 }
 
-RcppSMap4Lattice <- function(source, target, nb, lib, pred, theta, E = 3L, tau = 1L, b = 5L, threads = 8L) {
-    .Call(`_spEDM_RcppSMap4Lattice`, source, target, nb, lib, pred, theta, E, tau, b, threads)
+RcppSMap4Lattice <- function(source, target, nb, lib, pred, theta, E = 3L, tau = 1L, b = 5L, style = 1L, dist_metric = 2L, dist_average = TRUE, threads = 8L) {
+    .Call(`_spEDM_RcppSMap4Lattice`, source, target, nb, lib, pred, theta, E, tau, b, style, dist_metric, dist_average, threads)
 }
 
 RcppMultiView4Lattice <- function(x, y, nb, lib, pred, E = 3L, tau = 1L, b = 5L, top = 5L, nvar = 3L, threads = 8L) {

--- a/R/embedded.R
+++ b/R/embedded.R
@@ -15,7 +15,7 @@
 #' @param target name of target variable.
 #' @param E (optional) embedding dimensions.
 #' @param tau (optional) step of spatial lags.
-#' @param style (optional) embedding style (`0`` includes current state, `1` excludes it).
+#' @param style (optional) embedding style (`0` includes current state, `1` excludes it).
 #' @param nb (optional) neighbours list.
 #' @param detrend (optional) whether to remove the linear trend.
 #'

--- a/R/embedded.R
+++ b/R/embedded.R
@@ -15,7 +15,7 @@
 #' @param target name of target variable.
 #' @param E (optional) embedding dimensions.
 #' @param tau (optional) step of spatial lags.
-#' @param style (optional) embedding style; 0 includes current state, 1 excludes it.
+#' @param style (optional) embedding style (`0`` includes current state, `1` excludes it).
 #' @param nb (optional) neighbours list.
 #' @param detrend (optional) whether to remove the linear trend.
 #'

--- a/R/simplex.R
+++ b/R/simplex.R
@@ -1,21 +1,27 @@
 .simplex_sf_method = \(data,column,target,lib = NULL,pred = NULL,E = 2:10,tau = 1,
-                       k = E+2, nb = NULL, threads = detectThreads(), detrend = TRUE){
+                       k = E+2, style = 1, dist.metric = "L2", dist.average = TRUE,
+                       nb = NULL, threads = detectThreads(), detrend = TRUE){
   vx = .uni_lattice(data,column,detrend)
   vy = .uni_lattice(data,target,detrend)
   if (is.null(lib)) lib = .internal_library(cbind(vx,vy))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
-  res = RcppSimplex4Lattice(vx,vy,nb,lib,pred,E,k,tau,threads)
+  res = RcppSimplex4Lattice(vx,vy,nb,lib,pred,E,k,tau,style,
+                            ifelse(dist.metric == "L2", 2, 1),
+                            dist.average,threads)
   return(.bind_xmapself(res,target,"simplex",tau))
 }
 
 .simplex_spatraster_method = \(data,column,target,lib = NULL,pred = NULL,E = 2:10,tau = 1,
-                               k = E+2, threads = detectThreads(), detrend = TRUE){
+                               k = E+2, style = 1, dist.metric = "L2", dist.average = TRUE,
+                               threads = detectThreads(), detrend = TRUE){
   mx = .uni_grid(data,column,detrend)
   my = .uni_grid(data,target,detrend)
   if (is.null(lib)) lib = which(!(is.na(mx) | is.na(my)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
-  res = RcppSimplex4Grid(mx,my,lib,pred,E,k,tau,threads)
+  res = RcppSimplex4Grid(mx,my,lib,pred,E,k,tau,style,
+                            ifelse(dist.metric == "L2", 2, 1),
+                            dist.average,threads)
   return(.bind_xmapself(res,target,"simplex",tau))
 }
 
@@ -26,6 +32,8 @@
 #' @param lib (optional) libraries indices.
 #' @param pred (optional) predictions indices.
 #' @param k (optional) number of nearest neighbors used.
+#' @param dist.metric (optional) distance metric (`L1`: Manhattan, `L2`: Euclidean).
+#' @param dist.average (optional) whether to average distance.
 #' @param threads (optional) number of threads to use.
 #'
 #' @return A list

--- a/R/smap.R
+++ b/R/smap.R
@@ -1,4 +1,5 @@
-.smap_sf_method = \(data,column,target,lib = NULL,pred = NULL,E = 3,tau = 1,k = E+2,
+.smap_sf_method = \(data,column,target,lib = NULL,pred = NULL,E = 3,tau = 1,
+                    k = E+2,style = 1,dist.metric = "L2",dist.average = TRUE,
                     theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03,
                               0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8),
                     nb = NULL, threads = detectThreads(), detrend = TRUE){
@@ -7,11 +8,14 @@
   if (is.null(lib)) lib = .internal_library(cbind(vx,vy))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
-  res = RcppSMap4Lattice(vx,vy,nb,lib,pred,theta,E,tau,k,threads)
+  res = RcppSMap4Lattice(vx,vy,nb,lib,pred,theta,E,tau,k,style,
+                         ifelse(dist.metric == "L2", 2, 1),
+                         dist.average,threads)
   return(.bind_xmapself(res,target,"smap"))
 }
 
-.smap_spatraster_method = \(data,column,target,lib = NULL,pred = NULL,E = 3,tau = 1,k = E+2,
+.smap_spatraster_method = \(data,column,target,lib = NULL,pred = NULL,E = 3,tau = 1,
+                            k = E+2,style = 1,dist.metric = "L2",dist.average = TRUE,
                             theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03,
                                       0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8),
                             threads = detectThreads(), detrend = TRUE){
@@ -19,7 +23,9 @@
   my = .uni_grid(data,target,detrend)
   if (is.null(lib)) lib = which(!(is.na(mx) | is.na(my)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
-  res = RcppSMap4Grid(mx,my,lib,pred,theta,E,tau,k,threads)
+  res = RcppSMap4Grid(mx,my,lib,pred,theta,E,tau,k,style,
+                      ifelse(dist.metric == "L2", 2, 1),
+                      dist.average,threads)
   return(.bind_xmapself(res,target,"smap"))
 }
 

--- a/man/embedded.Rd
+++ b/man/embedded.Rd
@@ -19,7 +19,7 @@
 
 \item{tau}{(optional) step of spatial lags.}
 
-\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/man/embedded.Rd
+++ b/man/embedded.Rd
@@ -19,7 +19,7 @@
 
 \item{tau}{(optional) step of spatial lags.}
 
-\item{style}{(optional) embedding style; 0 includes current state, 1 excludes it.}
+\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -56,7 +56,7 @@
 
 \item{k}{(optional) number of nearest neighbors used.}
 
-\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
 
 \item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -15,6 +15,9 @@
   E = 2:10,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   nb = NULL,
   threads = detectThreads(),
   detrend = TRUE
@@ -29,6 +32,9 @@
   E = 2:10,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   threads = detectThreads(),
   detrend = TRUE
 )
@@ -49,6 +55,12 @@
 \item{tau}{(optional) step of spatial lags.}
 
 \item{k}{(optional) number of nearest neighbors used.}
+
+\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/man/smap.Rd
+++ b/man/smap.Rd
@@ -15,6 +15,9 @@
   E = 3,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3,
     4, 6, 8),
   nb = NULL,
@@ -31,6 +34,9 @@
   E = 3,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   theta = c(0, 1e-04, 3e-04, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 0.5, 0.75, 1, 1.5, 2, 3,
     4, 6, 8),
   threads = detectThreads(),
@@ -53,6 +59,12 @@
 \item{tau}{(optional) step of spatial lags.}
 
 \item{k}{(optional) number of nearest neighbors used.}
+
+\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{theta}{(optional) weighting parameter for distances.}
 

--- a/man/smap.Rd
+++ b/man/smap.Rd
@@ -60,7 +60,7 @@
 
 \item{k}{(optional) number of nearest neighbors used.}
 
-\item{style}{(optional) embedding style (\verb{0`` includes current state, }1` excludes it).}
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
 
 \item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 

--- a/src/Forecast4Grid.cpp
+++ b/src/Forecast4Grid.cpp
@@ -21,8 +21,11 @@
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - E: A vector of embedding dimensions to evaluate.
  *   - b: A vector of nearest neighbors to use for prediction.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - threads: Number of threads used from the global pool.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [E, b, rho, mae, rmse] for a given embedding dimension.
@@ -33,8 +36,11 @@ std::vector<std::vector<double>> Simplex4Grid(const std::vector<std::vector<doub
                                               const std::vector<int>& pred_indices,
                                               const std::vector<int>& E,
                                               const std::vector<int>& b,
-                                              int tau,
-                                              int threads) {
+                                              int tau = 1,
+                                              int style = 1,
+                                              int dist_metric = 2,
+                                              bool dist_average = true,
+                                              int threads = 8) {
   // Configure threads
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
@@ -75,10 +81,10 @@ std::vector<std::vector<double>> Simplex4Grid(const std::vector<std::vector<doub
     const int cur_b = unique_Ebcom[i].second;
 
     // Generate embedding
-    std::vector<std::vector<double>> embeddings = GenGridEmbeddings(source, cur_E, tau);
+    std::vector<std::vector<double>> embeddings = GenGridEmbeddings(source, cur_E, tau, style);
 
     // Evaluate performance
-    std::vector<double> metrics = SimplexBehavior(embeddings, vec_std, lib_indices, pred_indices, cur_b);
+    std::vector<double> metrics = SimplexBehavior(embeddings, vec_std, lib_indices, pred_indices, cur_b, dist_metric, dist_average);
 
     // Store results
     result[i][0] = cur_E;
@@ -100,10 +106,13 @@ std::vector<std::vector<double>> Simplex4Grid(const std::vector<std::vector<doub
  *   - lib_indices: A vector of indices indicating the library (training) set.
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - theta: A vector of weighting parameters for distance calculation in SMap.
- *   - E: The embedding dimension to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - b: Number of nearest neighbors to use for prediction.
- *   - threads: Number of threads used from the global pool.
+ *   - E: The embedding dimension to evaluate. Default is 3.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - b: Number of nearest neighbors to use for prediction. Default is 4.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [theta, rho, mae, rmse] for a given theta value.
@@ -113,10 +122,13 @@ std::vector<std::vector<double>> SMap4Grid(const std::vector<std::vector<double>
                                            const std::vector<int>& lib_indices,
                                            const std::vector<int>& pred_indices,
                                            const std::vector<double>& theta,
-                                           int E,
-                                           int tau,
-                                           int b,
-                                           int threads) {
+                                           int E = 3,
+                                           int tau = 1,
+                                           int b = 4,
+                                           int style = 1,
+                                           int dist_metric = 2,
+                                           bool dist_average = true,
+                                           int threads = 8) {
   // Configure threads
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
@@ -132,12 +144,12 @@ std::vector<std::vector<double>> SMap4Grid(const std::vector<std::vector<double>
   }
 
   // Generate embedding once
-  std::vector<std::vector<double>> embeddings = GenGridEmbeddings(source, E, tau);
+  std::vector<std::vector<double>> embeddings = GenGridEmbeddings(source, E, tau, style);
 
   std::vector<std::vector<double>> result(theta.size(), std::vector<double>(4));
 
   RcppThread::parallelFor(0, theta.size(), [&](size_t i) {
-    std::vector<double> metrics = SMapBehavior(embeddings, vec_std, lib_indices, pred_indices, b, theta[i]);
+    std::vector<double> metrics = SMapBehavior(embeddings, vec_std, lib_indices, pred_indices, b, theta[i], dist_average, dist_metric);
 
     result[i][0] = theta[i];
     result[i][1] = metrics[0];

--- a/src/Forecast4Grid.h
+++ b/src/Forecast4Grid.h
@@ -22,8 +22,11 @@
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - E: A vector of embedding dimensions to evaluate.
  *   - b: A vector of nearest neighbors to use for prediction.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - threads: Number of threads used from the global pool.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [E, b, rho, mae, rmse] for a given embedding dimension.
@@ -34,8 +37,11 @@ std::vector<std::vector<double>> Simplex4Grid(const std::vector<std::vector<doub
                                               const std::vector<int>& pred_indices,
                                               const std::vector<int>& E,
                                               const std::vector<int>& b,
-                                              int tau,
-                                              int threads);
+                                              int tau = 1,
+                                              int style = 1,
+                                              int dist_metric = 2,
+                                              bool dist_average = true,
+                                              int threads = 8);
 
 /*
  * Evaluates prediction performance of different theta parameters for grid data using the S-mapping method.
@@ -46,10 +52,13 @@ std::vector<std::vector<double>> Simplex4Grid(const std::vector<std::vector<doub
  *   - lib_indices: A vector of indices indicating the library (training) set.
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - theta: A vector of weighting parameters for distance calculation in SMap.
- *   - E: The embedding dimension to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - b: Number of nearest neighbors to use for prediction.
- *   - threads: Number of threads used from the global pool.
+ *   - E: The embedding dimension to evaluate. Default is 3.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - b: Number of nearest neighbors to use for prediction. Default is 4.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [theta, rho, mae, rmse] for a given theta value.
@@ -59,10 +68,13 @@ std::vector<std::vector<double>> SMap4Grid(const std::vector<std::vector<double>
                                            const std::vector<int>& lib_indices,
                                            const std::vector<int>& pred_indices,
                                            const std::vector<double>& theta,
-                                           int E,
-                                           int tau,
-                                           int b,
-                                           int threads);
+                                           int E = 3,
+                                           int tau = 1,
+                                           int b = 4,
+                                           int style = 1,
+                                           int dist_metric = 2,
+                                           bool dist_average = true,
+                                           int threads = 8);
 
 /**
  * @brief Evaluate intersection cardinality (IC) for spatial grid data.

--- a/src/Forecast4Lattice.cpp
+++ b/src/Forecast4Lattice.cpp
@@ -22,7 +22,7 @@
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - E: A vector of embedding dimensions to evaluate.
  *   - b: A vector of nearest neighbor values to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
  *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
  *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
  *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
@@ -38,7 +38,7 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
                                                  const std::vector<int>& pred_indices,
                                                  const std::vector<int>& E,
                                                  const std::vector<int>& b,
-                                                 int tau,
+                                                 int tau = 1,
                                                  int style = 1,
                                                  int dist_metric = 2,
                                                  bool dist_average = true,
@@ -91,9 +91,9 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
  *   - lib_indices: A vector of indices indicating the library (training) set.
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - theta: A vector of weighting parameters for distance calculation in SMap.
- *   - E: The embedding dimension to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - b: Number of nearest neighbors to use for prediction.
+ *   - E: The embedding dimension to evaluate. Default is 3.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - b: Number of nearest neighbors to use for prediction. Default is 4.
  *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
  *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
  *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
@@ -108,9 +108,9 @@ std::vector<std::vector<double>> SMap4Lattice(const std::vector<double>& source,
                                               const std::vector<int>& lib_indices,
                                               const std::vector<int>& pred_indices,
                                               const std::vector<double>& theta,
-                                              int E,
-                                              int tau,
-                                              int b,
+                                              int E = 3,
+                                              int tau = 1,
+                                              int b = 4,
                                               int style = 1,
                                               int dist_metric = 2,
                                               bool dist_average = true,

--- a/src/Forecast4Lattice.h
+++ b/src/Forecast4Lattice.h
@@ -24,7 +24,10 @@
  *   - E: A vector of embedding dimensions to evaluate.
  *   - b: A vector of nearest neighbor values to evaluate.
  *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - threads: Number of threads used from the global pool.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [E, b, rho, mae, rmse] for a given combination of E and b.
@@ -37,7 +40,10 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
                                                  const std::vector<int>& E,
                                                  const std::vector<int>& b,
                                                  int tau,
-                                                 int threads);
+                                                 int style = 1,
+                                                 int dist_metric = 2,
+                                                 bool dist_average = true,
+                                                 int threads = 8);
 
 /*
  * Evaluates prediction performance of different theta parameters for lattice data using the s-mapping method.
@@ -52,7 +58,10 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
  *   - E: The embedding dimension to evaluate.
  *   - tau: The spatial lag step for constructing lagged state-space vectors.
  *   - b: Number of nearest neighbors to use for prediction.
- *   - threads: Number of threads used from the global pool.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A 2D vector where each row contains [theta, rho, mae, rmse] for a given theta value.
@@ -66,7 +75,10 @@ std::vector<std::vector<double>> SMap4Lattice(const std::vector<double>& source,
                                               int E,
                                               int tau,
                                               int b,
-                                              int threads);
+                                              int style = 1,
+                                              int dist_metric = 2,
+                                              bool dist_average = true,
+                                              int threads = 8);
 
 /**
  * Compute Intersection Cardinality AUC over spatial lattice data.

--- a/src/Forecast4Lattice.h
+++ b/src/Forecast4Lattice.h
@@ -23,7 +23,7 @@
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - E: A vector of embedding dimensions to evaluate.
  *   - b: A vector of nearest neighbor values to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
  *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
  *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
  *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
@@ -39,7 +39,7 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
                                                  const std::vector<int>& pred_indices,
                                                  const std::vector<int>& E,
                                                  const std::vector<int>& b,
-                                                 int tau,
+                                                 int tau = 1,
                                                  int style = 1,
                                                  int dist_metric = 2,
                                                  bool dist_average = true,
@@ -55,9 +55,9 @@ std::vector<std::vector<double>> Simplex4Lattice(const std::vector<double>& sour
  *   - lib_indices: A vector of indices indicating the library (training) set.
  *   - pred_indices: A vector of indices indicating the prediction set.
  *   - theta: A vector of weighting parameters for distance calculation in SMap.
- *   - E: The embedding dimension to evaluate.
- *   - tau: The spatial lag step for constructing lagged state-space vectors.
- *   - b: Number of nearest neighbors to use for prediction.
+ *   - E: The embedding dimension to evaluate. Default is 3.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - b: Number of nearest neighbors to use for prediction. Default is 4.
  *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
  *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
  *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
@@ -72,9 +72,9 @@ std::vector<std::vector<double>> SMap4Lattice(const std::vector<double>& source,
                                               const std::vector<int>& lib_indices,
                                               const std::vector<int>& pred_indices,
                                               const std::vector<double>& theta,
-                                              int E,
-                                              int tau,
-                                              int b,
+                                              int E = 3,
+                                              int tau = 1,
+                                              int b = 4,
                                               int style = 1,
                                               int dist_metric = 2,
                                               bool dist_average = true,

--- a/src/ForecastExp.cpp
+++ b/src/ForecastExp.cpp
@@ -19,6 +19,8 @@
  *   - lib: Integer vector of indices (which states to include when searching for neighbors, 1-based indexing).
  *   - pred: Integer vector of indices (which states to predict from, 1-based indexing).
  *   - num_neighbors: Number of neighbors to be used for simplex projection.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). 
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns: A Rcpp::NumericVector containing the predicted target values.
  */
@@ -28,7 +30,10 @@ Rcpp::NumericVector RcppSimplexForecast(
     const Rcpp::NumericVector& target,
     const Rcpp::IntegerVector& lib,
     const Rcpp::IntegerVector& pred,
-    const int& num_neighbors = 4){
+    const int& num_neighbors = 4,
+    const int& dist_metric = 2,
+    const bool& dist_average = true
+  ){
   // Convert Rcpp NumericMatrix to std::vector<std::vector<double>>
   std::vector<std::vector<double>> embedding_std(embedding.nrow(),
                                                  std::vector<double>(embedding.ncol()));
@@ -66,7 +71,9 @@ Rcpp::NumericVector RcppSimplexForecast(
     target_std,
     lib_indices,
     pred_indices,
-    num_neighbors
+    num_neighbors,
+    dist_metric,
+    dist_average
   );
 
   // Convert the result back to Rcpp::NumericVector
@@ -86,6 +93,8 @@ Rcpp::NumericVector RcppSimplexForecast(
  *   - pred: Integer vector of indices (which states to predict from, 1-based indexing).
  *   - num_neighbors: Number of neighbors to be used for S-Mapping.
  *   - theta: Weighting parameter for distances.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). 
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns: A Rcpp::NumericVector containing the predicted target values.
  */
@@ -96,7 +105,9 @@ Rcpp::NumericVector RcppSMapForecast(
     const Rcpp::IntegerVector& lib,
     const Rcpp::IntegerVector& pred,
     const int& num_neighbors = 4,
-    const double& theta = 1.0){
+    const double& theta = 1.0,
+    const int& dist_metric = 2,
+    const bool& dist_average = true){
   // Convert Rcpp NumericMatrix to std::vector<std::vector<double>>
   std::vector<std::vector<double>> embedding_std(embedding.nrow(),
                                                  std::vector<double>(embedding.ncol()));
@@ -135,7 +146,9 @@ Rcpp::NumericVector RcppSMapForecast(
     lib_indices,
     pred_indices,
     num_neighbors,
-    theta
+    theta,
+    dist_metric,
+    dist_average
   );
 
   // Convert the result back to Rcpp::NumericVector

--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -565,7 +565,7 @@ Rcpp::NumericMatrix RcppSimplex4Grid(const Rcpp::NumericMatrix& source,
     E_std,
     b_std,
     tau,
-    style.
+    style,
     dist_metric,
     dist_average,
     threads);
@@ -679,7 +679,7 @@ Rcpp::NumericMatrix RcppSMap4Grid(const Rcpp::NumericMatrix& source,
     E,
     tau,
     b,
-    style.
+    style,
     dist_metric,
     dist_average,
     threads);

--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -484,6 +484,9 @@ Rcpp::NumericMatrix RcppSimplex4Grid(const Rcpp::NumericMatrix& source,
                                      const Rcpp::IntegerVector& E,
                                      const Rcpp::IntegerVector& b,
                                      int tau = 1,
+                                     int style = 1,
+                                     int dist_metric = 2,
+                                     bool dist_average = true,
                                      int threads = 8) {
   // Convert Rcpp::NumericMatrix to std::vector<std::vector<double>>
   int numRows = target.nrow();
@@ -562,6 +565,9 @@ Rcpp::NumericMatrix RcppSimplex4Grid(const Rcpp::NumericMatrix& source,
     E_std,
     b_std,
     tau,
+    style.
+    dist_metric,
+    dist_average,
     threads);
 
   size_t n_rows = res_std.size();
@@ -592,6 +598,9 @@ Rcpp::NumericMatrix RcppSMap4Grid(const Rcpp::NumericMatrix& source,
                                   int E = 3,
                                   int tau = 1,
                                   int b = 5,
+                                  int style = 1,
+                                  int dist_metric = 2,
+                                  bool dist_average = true,
                                   int threads = 8) {
   // Convert Rcpp::NumericMatrix to std::vector<std::vector<double>>
   int numRows = target.nrow();
@@ -670,6 +679,9 @@ Rcpp::NumericMatrix RcppSMap4Grid(const Rcpp::NumericMatrix& source,
     E,
     tau,
     b,
+    style.
+    dist_metric,
+    dist_average,
     threads);
 
   size_t n_rows = res_std.size();

--- a/src/LatticeExp.cpp
+++ b/src/LatticeExp.cpp
@@ -455,7 +455,11 @@ Rcpp::NumericVector RcppFNN4Lattice(
  *   - pred: An IntegerVector specifying the prediction indices (1-based in R, converted to 0-based in C++).
  *   - E: An IntegerVector specifying the embedding dimensions to test.
  *   - b: An IntegerVector specifying the numbers of neighbors to use for simplex projection.
- *   - tau: An integer specifying the step of spatial lags for prediction.
+ *   - tau: An integer specifying the step of spatial lags for prediction. Default is 1.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A NumericMatrix where each row contains {E, b, PearsonCor, MAE, RMSE}:
@@ -474,6 +478,9 @@ Rcpp::NumericMatrix RcppSimplex4Lattice(const Rcpp::NumericVector& source,
                                         const Rcpp::IntegerVector& E,
                                         const Rcpp::IntegerVector& b,
                                         int tau = 1,
+                                        int style = 1,
+                                        int dist_metric = 2,
+                                        bool dist_average = true,
                                         int threads = 8) {
   // Convert neighborhood list to std::vector<std::vector<int>>
   std::vector<std::vector<int>> nb_vec = nb2vec(nb);
@@ -520,6 +527,9 @@ Rcpp::NumericMatrix RcppSimplex4Lattice(const Rcpp::NumericVector& source,
     E_std,
     b_std,
     tau,
+    style,
+    dist_metric,
+    dist_average,
     threads);
 
   size_t n_rows = res_std.size();
@@ -548,10 +558,13 @@ Rcpp::NumericMatrix RcppSimplex4Lattice(const Rcpp::NumericVector& source,
  *   - lib: An IntegerVector specifying the library indices (1-based in R, converted to 0-based in C++).
  *   - pred: An IntegerVector specifying the prediction indices (1-based in R, converted to 0-based in C++).
  *   - theta: A NumericVector containing the parameter values to be tested for theta.
- *   - E: An integer specifying the embedding dimension to test.
- *   - tau: the step of spatial lags for prediction.
- *   - b: An integer specifying the number of neighbors to use for s-mapping.
- *   - threads: An integer specifying the number of threads to use for parallel computation.
+ *   - E: The embedding dimension to evaluate. Default is 3.
+ *   - tau: The spatial lag step for constructing lagged state-space vectors. Default is 1.
+ *   - b: Number of nearest neighbors to use for prediction. Default is 4.
+ *   - style: Embedding style selector (0: includes current state, 1: excludes it).  Default is 1 (excludes current state).
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean). Default is 2 (Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components. Default is true.
+ *   - threads: Number of threads used from the global pool. Default is 8.
  *
  * Returns:
  *   A NumericMatrix where each row contains {theta, PearsonCor, MAE, RMSE}:
@@ -572,6 +585,9 @@ Rcpp::NumericMatrix RcppSMap4Lattice(const Rcpp::NumericVector& source,
                                      int E = 3,
                                      int tau = 1,
                                      int b = 5,
+                                     int style = 1,
+                                     int dist_metric = 2,
+                                     bool dist_average = true,
                                      int threads = 8) {
   // Convert neighborhood list to std::vector<std::vector<int>>
   std::vector<std::vector<int>> nb_vec = nb2vec(nb);
@@ -616,6 +632,9 @@ Rcpp::NumericMatrix RcppSMap4Lattice(const Rcpp::NumericVector& source,
     E,
     tau,
     b,
+    style.
+    dist_metric,
+    dist_average,
     threads);
 
   size_t n_rows = res_std.size();

--- a/src/LatticeExp.cpp
+++ b/src/LatticeExp.cpp
@@ -632,7 +632,7 @@ Rcpp::NumericMatrix RcppSMap4Lattice(const Rcpp::NumericVector& source,
     E,
     tau,
     b,
-    style.
+    style,
     dist_metric,
     dist_average,
     threads);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -124,8 +124,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppSimplexForecast
-Rcpp::NumericVector RcppSimplexForecast(const Rcpp::NumericMatrix& embedding, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors);
-RcppExport SEXP _spEDM_RcppSimplexForecast(SEXP embeddingSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP) {
+Rcpp::NumericVector RcppSimplexForecast(const Rcpp::NumericMatrix& embedding, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const int& dist_metric, const bool& dist_average);
+RcppExport SEXP _spEDM_RcppSimplexForecast(SEXP embeddingSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type embedding(embeddingSEXP);
@@ -133,13 +133,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type lib(libSEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type pred(predSEXP);
     Rcpp::traits::input_parameter< const int& >::type num_neighbors(num_neighborsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSimplexForecast(embedding, target, lib, pred, num_neighbors));
+    Rcpp::traits::input_parameter< const int& >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type dist_average(dist_averageSEXP);
+    rcpp_result_gen = Rcpp::wrap(RcppSimplexForecast(embedding, target, lib, pred, num_neighbors, dist_metric, dist_average));
     return rcpp_result_gen;
 END_RCPP
 }
 // RcppSMapForecast
-Rcpp::NumericVector RcppSMapForecast(const Rcpp::NumericMatrix& embedding, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const double& theta);
-RcppExport SEXP _spEDM_RcppSMapForecast(SEXP embeddingSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP thetaSEXP) {
+Rcpp::NumericVector RcppSMapForecast(const Rcpp::NumericMatrix& embedding, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const double& theta, const int& dist_metric, const bool& dist_average);
+RcppExport SEXP _spEDM_RcppSMapForecast(SEXP embeddingSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP thetaSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type embedding(embeddingSEXP);
@@ -148,7 +150,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type pred(predSEXP);
     Rcpp::traits::input_parameter< const int& >::type num_neighbors(num_neighborsSEXP);
     Rcpp::traits::input_parameter< const double& >::type theta(thetaSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSMapForecast(embedding, target, lib, pred, num_neighbors, theta));
+    Rcpp::traits::input_parameter< const int& >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type dist_average(dist_averageSEXP);
+    rcpp_result_gen = Rcpp::wrap(RcppSMapForecast(embedding, target, lib, pred, num_neighbors, theta, dist_metric, dist_average));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -329,8 +333,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppSimplex4Grid
-Rcpp::NumericMatrix RcppSimplex4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int threads);
-RcppExport SEXP _spEDM_RcppSimplex4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP threadsSEXP) {
+Rcpp::NumericMatrix RcppSimplex4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int style, int dist_metric, bool dist_average, int threads);
+RcppExport SEXP _spEDM_RcppSimplex4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type source(sourceSEXP);
@@ -340,14 +344,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type E(ESEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSimplex4Grid(source, target, lib, pred, E, b, tau, threads));
+    rcpp_result_gen = Rcpp::wrap(RcppSimplex4Grid(source, target, lib, pred, E, b, tau, style, dist_metric, dist_average, threads));
     return rcpp_result_gen;
 END_RCPP
 }
 // RcppSMap4Grid
-Rcpp::NumericMatrix RcppSMap4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::NumericVector& theta, int E, int tau, int b, int threads);
-RcppExport SEXP _spEDM_RcppSMap4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP thetaSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP threadsSEXP) {
+Rcpp::NumericMatrix RcppSMap4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::NumericVector& theta, int E, int tau, int b, int style, int dist_metric, bool dist_average, int threads);
+RcppExport SEXP _spEDM_RcppSMap4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP thetaSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type source(sourceSEXP);
@@ -358,8 +365,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type E(ESEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type b(bSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSMap4Grid(source, target, lib, pred, theta, E, tau, b, threads));
+    rcpp_result_gen = Rcpp::wrap(RcppSMap4Grid(source, target, lib, pred, theta, E, tau, b, style, dist_metric, dist_average, threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -711,8 +721,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppSimplex4Lattice
-Rcpp::NumericMatrix RcppSimplex4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int threads);
-RcppExport SEXP _spEDM_RcppSimplex4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP threadsSEXP) {
+Rcpp::NumericMatrix RcppSimplex4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int style, int dist_metric, bool dist_average, int threads);
+RcppExport SEXP _spEDM_RcppSimplex4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type source(sourceSEXP);
@@ -723,14 +733,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type E(ESEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSimplex4Lattice(source, target, nb, lib, pred, E, b, tau, threads));
+    rcpp_result_gen = Rcpp::wrap(RcppSimplex4Lattice(source, target, nb, lib, pred, E, b, tau, style, dist_metric, dist_average, threads));
     return rcpp_result_gen;
 END_RCPP
 }
 // RcppSMap4Lattice
-Rcpp::NumericMatrix RcppSMap4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::NumericVector& theta, int E, int tau, int b, int threads);
-RcppExport SEXP _spEDM_RcppSMap4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP thetaSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP threadsSEXP) {
+Rcpp::NumericMatrix RcppSMap4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::NumericVector& theta, int E, int tau, int b, int style, int dist_metric, bool dist_average, int threads);
+RcppExport SEXP _spEDM_RcppSMap4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP thetaSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type source(sourceSEXP);
@@ -742,8 +755,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type E(ESEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type b(bSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppSMap4Lattice(source, target, nb, lib, pred, theta, E, tau, b, threads));
+    rcpp_result_gen = Rcpp::wrap(RcppSMap4Lattice(source, target, nb, lib, pred, theta, E, tau, b, style, dist_metric, dist_average, threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1409,8 +1425,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppJoinEntropy_Disc", (DL_FUNC) &_spEDM_RcppJoinEntropy_Disc, 4},
     {"_spEDM_RcppMutualInformation_Disc", (DL_FUNC) &_spEDM_RcppMutualInformation_Disc, 5},
     {"_spEDM_RcppConditionalEntropy_Disc", (DL_FUNC) &_spEDM_RcppConditionalEntropy_Disc, 5},
-    {"_spEDM_RcppSimplexForecast", (DL_FUNC) &_spEDM_RcppSimplexForecast, 5},
-    {"_spEDM_RcppSMapForecast", (DL_FUNC) &_spEDM_RcppSMapForecast, 6},
+    {"_spEDM_RcppSimplexForecast", (DL_FUNC) &_spEDM_RcppSimplexForecast, 7},
+    {"_spEDM_RcppSMapForecast", (DL_FUNC) &_spEDM_RcppSMapForecast, 8},
     {"_spEDM_RcppIntersectionCardinality", (DL_FUNC) &_spEDM_RcppIntersectionCardinality, 8},
     {"_spEDM_RcppLocateGridIndices", (DL_FUNC) &_spEDM_RcppLocateGridIndices, 4},
     {"_spEDM_RcppRowColFromGrid", (DL_FUNC) &_spEDM_RcppRowColFromGrid, 2},
@@ -1423,8 +1439,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSLMBi4Grid", (DL_FUNC) &_spEDM_RcppSLMBi4Grid, 9},
     {"_spEDM_RcppSLMTri4Grid", (DL_FUNC) &_spEDM_RcppSLMTri4Grid, 15},
     {"_spEDM_RcppFNN4Grid", (DL_FUNC) &_spEDM_RcppFNN4Grid, 9},
-    {"_spEDM_RcppSimplex4Grid", (DL_FUNC) &_spEDM_RcppSimplex4Grid, 8},
-    {"_spEDM_RcppSMap4Grid", (DL_FUNC) &_spEDM_RcppSMap4Grid, 9},
+    {"_spEDM_RcppSimplex4Grid", (DL_FUNC) &_spEDM_RcppSimplex4Grid, 11},
+    {"_spEDM_RcppSMap4Grid", (DL_FUNC) &_spEDM_RcppSMap4Grid, 12},
     {"_spEDM_RcppMultiView4Grid", (DL_FUNC) &_spEDM_RcppMultiView4Grid, 10},
     {"_spEDM_RcppIC4Grid", (DL_FUNC) &_spEDM_RcppIC4Grid, 10},
     {"_spEDM_RcppGCCM4Grid", (DL_FUNC) &_spEDM_RcppGCCM4Grid, 13},
@@ -1447,8 +1463,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSLMBi4Lattice", (DL_FUNC) &_spEDM_RcppSLMBi4Lattice, 10},
     {"_spEDM_RcppSLMTri4Lattice", (DL_FUNC) &_spEDM_RcppSLMTri4Lattice, 16},
     {"_spEDM_RcppFNN4Lattice", (DL_FUNC) &_spEDM_RcppFNN4Lattice, 10},
-    {"_spEDM_RcppSimplex4Lattice", (DL_FUNC) &_spEDM_RcppSimplex4Lattice, 9},
-    {"_spEDM_RcppSMap4Lattice", (DL_FUNC) &_spEDM_RcppSMap4Lattice, 10},
+    {"_spEDM_RcppSimplex4Lattice", (DL_FUNC) &_spEDM_RcppSimplex4Lattice, 12},
+    {"_spEDM_RcppSMap4Lattice", (DL_FUNC) &_spEDM_RcppSMap4Lattice, 13},
     {"_spEDM_RcppMultiView4Lattice", (DL_FUNC) &_spEDM_RcppMultiView4Lattice, 11},
     {"_spEDM_RcppIC4Lattice", (DL_FUNC) &_spEDM_RcppIC4Lattice, 11},
     {"_spEDM_RcppGCCM4Lattice", (DL_FUNC) &_spEDM_RcppGCCM4Lattice, 14},


### PR DESCRIPTION
New `style` `dist.metric` `dist.average` parames in `simplex` and `smap` generics:
- `style`: embedding style selector (`0`: includes current state, `1`: excludes it).
- `dist.metric`: distance metric (`L1`: Manhattan, `L2`: Euclidean)
- `dist.average`: whether to average distance by the number of valid vector components