### PR TITLE
synchronize support for independent metric selection and embedding styles in intersection cardinality operations

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,8 +41,8 @@ RcppSMapForecast <- function(embedding, target, lib, pred, num_neighbors = 4L, t
     .Call(`_spEDM_RcppSMapForecast`, embedding, target, lib, pred, num_neighbors, theta, dist_metric, dist_average)
 }
 
-RcppIntersectionCardinality <- function(embedding_x, embedding_y, lib, pred, num_neighbors = 4L, n_excluded = 0L, threads = 8L, parallel_level = 0L) {
-    .Call(`_spEDM_RcppIntersectionCardinality`, embedding_x, embedding_y, lib, pred, num_neighbors, n_excluded, threads, parallel_level)
+RcppIntersectionCardinality <- function(embedding_x, embedding_y, lib, pred, num_neighbors = 4L, n_excluded = 0L, dist_metric = 2L, threads = 8L, parallel_level = 0L) {
+    .Call(`_spEDM_RcppIntersectionCardinality`, embedding_x, embedding_y, lib, pred, num_neighbors, n_excluded, dist_metric, threads, parallel_level)
 }
 
 RcppLocateGridIndices <- function(curRow, curCol, totalRow, totalCol) {
@@ -101,8 +101,8 @@ RcppMultiView4Grid <- function(xMatrix, yMatrix, lib, pred, E = 3L, tau = 1L, b 
     .Call(`_spEDM_RcppMultiView4Grid`, xMatrix, yMatrix, lib, pred, E, tau, b, top, nvar, style, dist_metric, dist_average, threads)
 }
 
-RcppIC4Grid <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L, threads = 8L, parallel_level = 0L) {
-    .Call(`_spEDM_RcppIC4Grid`, source, target, lib, pred, E, b, tau, exclude, threads, parallel_level)
+RcppIC4Grid <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L, style = 1L, dist_metric = 2L, threads = 8L, parallel_level = 0L) {
+    .Call(`_spEDM_RcppIC4Grid`, source, target, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level)
 }
 
 RcppGCCM4Grid <- function(xMatrix, yMatrix, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
@@ -113,8 +113,8 @@ RcppSCPCM4Grid <- function(xMatrix, yMatrix, zMatrix, libsizes, lib, pred, E, ta
     .Call(`_spEDM_RcppSCPCM4Grid`, xMatrix, yMatrix, zMatrix, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, progressbar)
 }
 
-RcppGCMC4Grid <- function(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, r = 0L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_spEDM_RcppGCMC4Grid`, xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar)
+RcppGCMC4Grid <- function(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b = 4L, r = 0L, style = 1L, dist_metric = 2L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
+    .Call(`_spEDM_RcppGCMC4Grid`, xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, r, style, dist_metric, threads, parallel_level, progressbar)
 }
 
 RcppSGCSingle4Grid <- function(x, y, lib, pred, k, base = 2, symbolize = TRUE, normalize = FALSE) {
@@ -197,8 +197,8 @@ RcppMultiView4Lattice <- function(x, y, nb, lib, pred, E = 3L, tau = 1L, b = 5L,
     .Call(`_spEDM_RcppMultiView4Lattice`, x, y, nb, lib, pred, E, tau, b, top, nvar, style, dist_metric, dist_average, threads)
 }
 
-RcppIC4Lattice <- function(source, target, nb, lib, pred, E, b, tau = 1L, exclude = 0L, threads = 8L, parallel_level = 0L) {
-    .Call(`_spEDM_RcppIC4Lattice`, source, target, nb, lib, pred, E, b, tau, exclude, threads, parallel_level)
+RcppIC4Lattice <- function(source, target, nb, lib, pred, E, b, tau = 1L, exclude = 0L, style = 1L, dist_metric = 2L, threads = 8L, parallel_level = 0L) {
+    .Call(`_spEDM_RcppIC4Lattice`, source, target, nb, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level)
 }
 
 RcppGCCM4Lattice <- function(x, y, nb, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
@@ -209,8 +209,8 @@ RcppSCPCM4Lattice <- function(x, y, z, nb, libsizes, lib, pred, E, tau, b, simpl
     .Call(`_spEDM_RcppSCPCM4Lattice`, x, y, z, nb, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, progressbar)
 }
 
-RcppGCMC4Lattice <- function(x, y, nb, libsizes, lib, pred, E, tau, b, r = 0L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_spEDM_RcppGCMC4Lattice`, x, y, nb, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar)
+RcppGCMC4Lattice <- function(x, y, nb, libsizes, lib, pred, E, tau, b = 4L, r = 0L, style = 1L, dist_metric = 2L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
+    .Call(`_spEDM_RcppGCMC4Lattice`, x, y, nb, libsizes, lib, pred, E, tau, b, r, style, dist_metric, threads, parallel_level, progressbar)
 }
 
 RcppSGCSingle4Lattice <- function(x, y, nb, lib, pred, k, base = 2, symbolize = TRUE, normalize = FALSE) {
@@ -369,8 +369,8 @@ RcppDistSortedIndice <- function(dist_mat, lib, k, include_self = FALSE) {
     .Call(`_spEDM_RcppDistSortedIndice`, dist_mat, lib, k, include_self)
 }
 
-RcppMatKNNeighbors <- function(embeddings, lib, k, threads = 8L) {
-    .Call(`_spEDM_RcppMatKNNeighbors`, embeddings, lib, k, threads)
+RcppMatKNNeighbors <- function(embeddings, lib, k, threads = 8L, L1norm = FALSE) {
+    .Call(`_spEDM_RcppMatKNNeighbors`, embeddings, lib, k, threads, L1norm)
 }
 
 RcppLinearTrendRM <- function(vec, xcoord, ycoord, NA_rm = FALSE) {

--- a/R/gcmc.R
+++ b/R/gcmc.R
@@ -1,5 +1,5 @@
-.gcmc_sf_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = pmin(E^2), lib = NULL, pred = NULL, nb = NULL,
-                    threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = FALSE, progressbar = TRUE){
+.gcmc_sf_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = pmin(E^2), lib = NULL, pred = NULL, style = 1, dist.metric = "L2",
+                    nb = NULL, threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = FALSE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -24,14 +24,16 @@
 
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppGCMC4Lattice(cause,effect,nb,libsizes,lib,pred,E,tau,k[1],0,threads,pl,progressbar)
+    x_xmap_y = RcppGCMC4Lattice(cause,effect,nb,libsizes,lib,pred,E,tau,k[1],0,style,
+                                .check_distmetric(dist.metric),threads,pl,progressbar)
   }
-  y_xmap_x = RcppGCMC4Lattice(effect,cause,nb,libsizes,lib,pred,rev(E),rev(tau),k[2],0,threads,pl,progressbar)
+  y_xmap_x = RcppGCMC4Lattice(effect,cause,nb,libsizes,lib,pred,rev(E),rev(tau),k[2],0,
+                              style, .check_distmetric(dist.metric),threads,pl,progressbar)
 
   return(.bind_intersectdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
 
-.gcmc_spatraster_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = pmin(E^2), lib = NULL, pred = NULL,
+.gcmc_spatraster_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = pmin(E^2), lib = NULL, pred = NULL, style = 1, dist.metric = "L2",
                             threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = FALSE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
@@ -55,9 +57,11 @@
 
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppGCMC4Grid(causemat,effectmat,libsizes,lib,pred,E,tau,k[1],0,threads,pl,progressbar)
+    x_xmap_y = RcppGCMC4Grid(causemat,effectmat,libsizes,lib,pred,E,tau,k[1],0,style,
+                             .check_distmetric(dist.metric),threads,pl,progressbar)
   }
-  y_xmap_x = RcppGCMC4Grid(effectmat,causemat,libsizes,lib,pred,rev(E),rev(tau),k[2],0,threads,pl,progressbar)
+  y_xmap_x = RcppGCMC4Grid(effectmat,causemat,libsizes,lib,pred,rev(E),rev(tau),k[2],0,
+                           style,.check_distmetric(dist.metric),threads,pl,progressbar)
 
   return(.bind_intersectdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
@@ -73,6 +77,8 @@
 #' @param k (optional) number of nearest neighbors.
 #' @param lib (optional) libraries indices.
 #' @param pred (optional) predictions indices.
+#' @param style (optional) embedding style (`0` includes current state, `1` excludes it).
+#' @param dist.metric (optional) distance metric (`L1`: Manhattan, `L2`: Euclidean).
 #' @param nb (optional) neighbours list.
 #' @param threads (optional) number of threads to use.
 #' @param parallel.level (optional) level of parallelism, `low` or `high`.

--- a/R/ic.R
+++ b/R/ic.R
@@ -1,23 +1,25 @@
-.ic_sf_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 1, k = E+2,
-                  nb = NULL, threads = detectThreads(), parallel.level = "low", detrend = FALSE){
+.ic_sf_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 1, k = E+2, style = 1, 
+                  dist.metric = "L2", nb = NULL, threads = detectThreads(), parallel.level = "low", detrend = FALSE){
   vx = .uni_lattice(data,column,detrend)
   vy = .uni_lattice(data,target,detrend)
   if (is.null(lib)) lib = .internal_library(cbind(vx,vy))
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   pl = .check_parallellevel(parallel.level)
-  res = RcppIC4Lattice(vx,vy,nb,lib,pred,E,k,tau,0,threads,pl)
+  res = RcppIC4Lattice(vx, vy, nb, lib, pred, E, k, tau, 0, style,
+                       .check_distmetric(dist.metric),threads,pl)
   return(.bind_xmapself(res,target,"ic",tau))
 }
 
-.ic_spatraster_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 1, k = E+2,
-                          threads = detectThreads(), parallel.level = "low", detrend = FALSE){
+.ic_spatraster_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 1, k = E+2, style = 1, 
+                          dist.metric = "L2", threads = detectThreads(), parallel.level = "low", detrend = FALSE){
   mx = .uni_grid(data,column,detrend)
   my = .uni_grid(data,target,detrend)
   if (is.null(lib)) lib = which(!(is.na(mx) | is.na(my)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
   pl = .check_parallellevel(parallel.level)
-  res = RcppIC4Grid(mx,my,lib,pred,E,k,tau,0,threads,pl)
+  res = RcppIC4Grid(mx, my, lib, pred, E, k, tau, 0, style,
+                    .check_distmetric(dist.metric),threads,pl)
   return(.bind_xmapself(res,target,"ic",tau))
 }
 

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -27,6 +27,14 @@
   return(pl)
 }
 
+.check_distmetric = \(dist.metric){
+  dm = 2
+  if (dist.metric != "L2"){
+    dm = 1
+  }
+  return(dm)
+}
+
 .internal_varname = \(conds = NULL){
   .varname = c("cause","effect")
   if (!is.null(conds)){

--- a/R/multiview.R
+++ b/R/multiview.R
@@ -8,7 +8,7 @@
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   if (is.null(top)) top = 0
   res = RcppMultiView4Lattice(xmat, yvec, nb, lib, pred, E, tau, k, top, nvar, style,
-                              ifelse(dist.metric == "L2", 2, 1), dist.average, threads)
+                              .check_distmetric(dist.metric), dist.average, threads)
   return(res)
 }
 
@@ -21,7 +21,7 @@
   if (is.null(pred)) pred = lib
   if (is.null(top)) top = 0
   res = RcppMultiView4Grid(xmat, ymat, lib, pred, E, tau, k, top, nvar, style,
-                           ifelse(dist.metric == "L2", 2, 1), dist.average, threads)
+                           .check_distmetric(dist.metric), dist.average, threads)
   return(res)
 }
 

--- a/R/simplex.R
+++ b/R/simplex.R
@@ -7,7 +7,7 @@
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   res = RcppSimplex4Lattice(vx,vy,nb,lib,pred,E,k,tau,style,
-                            ifelse(dist.metric == "L2", 2, 1),
+                            .check_distmetric(dist.metric),
                             dist.average,threads)
   return(.bind_xmapself(res,target,"simplex",tau))
 }
@@ -20,8 +20,8 @@
   if (is.null(lib)) lib = which(!(is.na(mx) | is.na(my)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
   res = RcppSimplex4Grid(mx,my,lib,pred,E,k,tau,style,
-                            ifelse(dist.metric == "L2", 2, 1),
-                            dist.average,threads)
+                         .check_distmetric(dist.metric),
+                         dist.average,threads)
   return(.bind_xmapself(res,target,"simplex",tau))
 }
 

--- a/R/smap.R
+++ b/R/smap.R
@@ -9,8 +9,8 @@
   if (is.null(pred)) pred = lib
   if (is.null(nb)) nb = .internal_lattice_nb(data)
   res = RcppSMap4Lattice(vx,vy,nb,lib,pred,theta,E,tau,k,style,
-                         ifelse(dist.metric == "L2", 2, 1),
-                         dist.average,threads)
+                         .check_distmetric(dist.metric), 
+                         dist.average, threads)
   return(.bind_xmapself(res,target,"smap"))
 }
 
@@ -24,7 +24,7 @@
   if (is.null(lib)) lib = which(!(is.na(mx) | is.na(my)), arr.ind = TRUE)
   if (is.null(pred)) pred = lib
   res = RcppSMap4Grid(mx,my,lib,pred,theta,E,tau,k,style,
-                      ifelse(dist.metric == "L2", 2, 1),
+                      .check_distmetric(dist.metric),
                       dist.average,threads)
   return(.bind_xmapself(res,target,"smap"))
 }

--- a/man/gcmc.Rd
+++ b/man/gcmc.Rd
@@ -16,6 +16,8 @@
   k = pmin(E^2),
   lib = NULL,
   pred = NULL,
+  style = 1,
+  dist.metric = "L2",
   nb = NULL,
   threads = detectThreads(),
   parallel.level = "low",
@@ -34,6 +36,8 @@
   k = pmin(E^2),
   lib = NULL,
   pred = NULL,
+  style = 1,
+  dist.metric = "L2",
   threads = detectThreads(),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -59,6 +63,10 @@
 \item{lib}{(optional) libraries indices.}
 
 \item{pred}{(optional) predictions indices.}
+
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/man/ic.Rd
+++ b/man/ic.Rd
@@ -15,6 +15,8 @@
   E = 2:10,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
   nb = NULL,
   threads = detectThreads(),
   parallel.level = "low",
@@ -30,6 +32,8 @@
   E = 2:10,
   tau = 1,
   k = E + 2,
+  style = 1,
+  dist.metric = "L2",
   threads = detectThreads(),
   parallel.level = "low",
   detrend = FALSE
@@ -51,6 +55,10 @@
 \item{tau}{(optional) step of spatial lags.}
 
 \item{k}{(optional) number of nearest neighbors used.}
+
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/src/CppDistances.cpp
+++ b/src/CppDistances.cpp
@@ -456,6 +456,7 @@ std::vector<std::vector<size_t>> CppDistSortedIndice(
  * @param lib A vector of indices representing the subset of points to consider for neighbor search.
  * @param k The number of nearest neighbors to find for each point in 'lib'.
  * @param threads The number of threads to use for parallel computation.
+ * @param L1norm Flag to use Manhattan distance (true) or Euclidean distance (false).
  * @return std::vector<std::vector<size_t>> A vector where each row corresponds to an embedding_space
  *         point and contains the indices of its k nearest neighbors from 'lib', or an invalid index if not in 'lib'.
  */
@@ -463,7 +464,8 @@ std::vector<std::vector<size_t>> CppMatKNNeighbors(
     const std::vector<std::vector<double>>& embedding_space,
     const std::vector<size_t>& lib,
     size_t k,
-    size_t threads) {
+    size_t threads,
+    bool L1norm = false) {
 
   const size_t n = embedding_space.size();
   const size_t invalid_index = std::numeric_limits<size_t>::max();
@@ -485,7 +487,7 @@ std::vector<std::vector<size_t>> CppMatKNNeighbors(
   //     if (idx_i == idx_j) continue;  // Skip distance to self
   //     size_t j = lib[idx_j];
   //
-  //     double dist = CppDistance(embedding_space[i], embedding_space[j], false, true);
+  //     double dist = CppDistance(embedding_space[i], embedding_space[j], L1norm, true);
   //
   //     if (std::isnan(dist)) continue; // Skip invalid distances
   //
@@ -520,7 +522,7 @@ std::vector<std::vector<size_t>> CppMatKNNeighbors(
       if (idx_i == idx_j) continue;  // Skip distance to self
       size_t j = lib[idx_j];
 
-      double dist = CppDistance(embedding_space[i], embedding_space[j], false, true);
+      double dist = CppDistance(embedding_space[i], embedding_space[j], L1norm, true);
 
       if (std::isnan(dist)) continue; // Skip invalid distances
 

--- a/src/CppDistances.h
+++ b/src/CppDistances.h
@@ -68,6 +68,7 @@ std::vector<std::vector<size_t>> CppMatKNNeighbors(
     const std::vector<std::vector<double>>& embedding_space,
     const std::vector<size_t>& lib,
     size_t k,
-    size_t threads);
+    size_t threads,
+    bool L1norm = false);
 
 #endif // CppDistances_H

--- a/src/CrossMappingCardinality.cpp
+++ b/src/CrossMappingCardinality.cpp
@@ -27,6 +27,7 @@
  * @param pred Indices of prediction points (0-based).
  * @param num_neighbors Number of neighbors used in cross mapping.
  * @param n_excluded Number of temporally excluded neighbors (Theiler window).
+ * @param dist_metric Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads Number of threads for parallel processing.
  * @param parallel_level Level of parallelism to control nested parallel execution.
  * @param progressbar Boolean flag to show or hide a progress bar.
@@ -43,6 +44,7 @@ CMCRes CrossMappingCardinality(
     const std::vector<size_t>& pred,
     size_t num_neighbors = 4,
     size_t n_excluded = 0,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = true) {
@@ -84,13 +86,16 @@ CMCRes CrossMappingCardinality(
   std::sort(unique_lib_sizes.begin(), unique_lib_sizes.end());
   unique_lib_sizes.erase(std::unique(unique_lib_sizes.begin(), unique_lib_sizes.end()), unique_lib_sizes.end());
 
+  // Use L1 norm (Manhattan distance) if dist_metric == 1, else use L2 norm
+  bool L1norm = (dist_metric == 1);
+
   // // Precompute neighbors (The earlier implementation based on a serial version)
-  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, false, true), lib, num_neighbors + n_excluded);
-  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, false, true), lib, num_neighbors + n_excluded);
+  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, L1norm, true), lib, num_neighbors + n_excluded);
+  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, L1norm, true), lib, num_neighbors + n_excluded);
 
   // Precompute neighbors (parallel computation)
-  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet);
-  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet);
+  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
+  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
 
   // Local results for each library
   std::vector<std::vector<IntersectionRes>> local_results(unique_lib_sizes.size());

--- a/src/CrossMappingCardinality.h
+++ b/src/CrossMappingCardinality.h
@@ -14,7 +14,6 @@
 #include "IntersectionCardinality.h"
 #include <RcppThread.h>
 
-
 /**
  * @brief Computes the Cross Mapping Cardinality (CMC) causal strength score.
  *
@@ -29,6 +28,7 @@
  * @param pred Indices of prediction points (0-based).
  * @param num_neighbors Number of neighbors used in cross mapping.
  * @param n_excluded Number of temporally excluded neighbors (Theiler window).
+ * @param dist_metric Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads Number of threads for parallel processing.
  * @param parallel_level Level of parallelism to control nested parallel execution.
  * @param progressbar Boolean flag to show or hide a progress bar.
@@ -45,6 +45,7 @@ CMCRes CrossMappingCardinality(
     const std::vector<size_t>& pred,
     size_t num_neighbors = 4,
     size_t n_excluded = 0,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = true);

--- a/src/Forecast4Grid.cpp
+++ b/src/Forecast4Grid.cpp
@@ -183,6 +183,8 @@ std::vector<std::vector<double>> SMap4Grid(const std::vector<std::vector<double>
  * @param b Vector of neighbor counts (k) used to compute IC.
  * @param tau Spatial embedding spacing (lag). Determines distance between embedding neighbors.
  * @param exclude Number of nearest neighbors to exclude in IC computation.
+ * @param style Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads Maximum number of threads to use.
  * @param parallel_level If > 0, enables parallel evaluation of b for each E.
  *
@@ -194,10 +196,12 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
                                          const std::vector<size_t>& pred_indices,
                                          const std::vector<int>& E,
                                          const std::vector<int>& b,
-                                         int tau,
-                                         int exclude,
-                                         int threads,
-                                         int parallel_level) {
+                                         int tau = 1,
+                                         int exclude = 0,
+                                         int style = 1,
+                                         int dist_metric = 2,
+                                         int threads = 8,
+                                         int parallel_level = 0) {
   // Configure threads
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
@@ -230,8 +234,8 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
   if (parallel_level == 0){
     for (size_t i = 0; i < Es.size(); ++i) {
       // Generate embeddings
-      auto embedding_x = GenGridEmbeddings(source, Es[i], tau);
-      auto embedding_y = GenGridEmbeddings(target, Es[i], tau);
+      auto embedding_x = GenGridEmbeddings(source, Es[i], tau, style);
+      auto embedding_y = GenGridEmbeddings(target, Es[i], tau, style);
 
       // Filter valid prediction points (exclude those with all NaN values)
       std::vector<size_t> valid_pred;
@@ -245,13 +249,16 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
         if (!x_nan && !y_nan) valid_pred.push_back(idx);
       }
 
+      // Use L1 norm (Manhattan distance) if dist_metric == 1, else use L2 norm
+      bool L1norm = (dist_metric == 1);
+
       // // Precompute neighbors (The earlier implementation based on a serial version)
-      // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, false, true),lib_indices,max_num_neighbors);
-      // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, false, true),lib_indices,max_num_neighbors);
+      // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, L1norm, true),lib_indices,max_num_neighbors);
+      // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, L1norm, true),lib_indices,max_num_neighbors);
 
       // Precompute neighbors (parallel computation)
-      auto nx = CppMatKNNeighbors(embedding_x, lib_indices, max_num_neighbors, threads_sizet);
-      auto ny = CppMatKNNeighbors(embedding_y, lib_indices, max_num_neighbors, threads_sizet);
+      auto nx = CppMatKNNeighbors(embedding_x, lib_indices, max_num_neighbors, threads_sizet, L1norm);
+      auto ny = CppMatKNNeighbors(embedding_y, lib_indices, max_num_neighbors, threads_sizet, L1norm);
 
       // Parameter initialization
       const size_t n_excluded_sizet = static_cast<size_t>(exclude);
@@ -276,8 +283,8 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
   } else {
     for (size_t i = 0; i < Es.size(); ++i) {
       // Generate embeddings
-      auto embedding_x = GenGridEmbeddings(source, Es[i], tau);
-      auto embedding_y = GenGridEmbeddings(target, Es[i], tau);
+      auto embedding_x = GenGridEmbeddings(source, Es[i], tau, style);
+      auto embedding_y = GenGridEmbeddings(target, Es[i], tau, style);
 
       // Filter valid prediction points (exclude those with all NaN values)
       std::vector<size_t> valid_pred;
@@ -291,13 +298,16 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
         if (!x_nan && !y_nan) valid_pred.push_back(idx);
       }
 
+      // Use L1 norm (Manhattan distance) if dist_metric == 1, else use L2 norm
+      bool L1norm = (dist_metric == 1);
+
       // // Precompute neighbors (The earlier implementation based on a serial version)
-      // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, false, true),lib_indices,max_num_neighbors);
-      // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, false, true),lib_indices,max_num_neighbors);
+      // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, L1norm, true),lib_indices,max_num_neighbors);
+      // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, L1norm, true),lib_indices,max_num_neighbors);
 
       // Precompute neighbors (parallel computation)
-      auto nx = CppMatKNNeighbors(embedding_x, lib_indices, max_num_neighbors, threads_sizet);
-      auto ny = CppMatKNNeighbors(embedding_y, lib_indices, max_num_neighbors, threads_sizet);
+      auto nx = CppMatKNNeighbors(embedding_x, lib_indices, max_num_neighbors, threads_sizet, L1norm);
+      auto ny = CppMatKNNeighbors(embedding_y, lib_indices, max_num_neighbors, threads_sizet, L1norm);
 
       // Parameter initialization
       const size_t n_excluded_sizet = static_cast<size_t>(exclude);

--- a/src/Forecast4Grid.h
+++ b/src/Forecast4Grid.h
@@ -99,6 +99,8 @@ std::vector<std::vector<double>> SMap4Grid(const std::vector<std::vector<double>
  * @param b Vector of neighbor counts (k) used to compute IC.
  * @param tau Spatial embedding spacing (lag). Determines distance between embedding neighbors.
  * @param exclude Number of nearest neighbors to exclude in IC computation.
+ * @param style Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads Maximum number of threads to use.
  * @param parallel_level If > 0, enables parallel evaluation of b for each E.
  *
@@ -110,9 +112,11 @@ std::vector<std::vector<double>> IC4Grid(const std::vector<std::vector<double>>&
                                          const std::vector<size_t>& pred_indices,
                                          const std::vector<int>& E,
                                          const std::vector<int>& b,
-                                         int tau,
-                                         int exclude,
-                                         int threads,
-                                         int parallel_level);
+                                         int tau = 1,
+                                         int exclude = 0,
+                                         int style = 1,
+                                         int dist_metric = 2,
+                                         int threads = 8,
+                                         int parallel_level = 0);
 
 #endif // Forecast4Grid_H

--- a/src/Forecast4Lattice.h
+++ b/src/Forecast4Lattice.h
@@ -103,6 +103,8 @@ std::vector<std::vector<double>> SMap4Lattice(const std::vector<double>& source,
  * @param b              Vector of neighbor sizes to try.
  * @param tau            Embedding delay (usually 1 for lattice).
  * @param exclude        Number of nearest neighbors to exclude (e.g., temporal or spatial proximity).
+ * @param style          Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric    Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads        Number of threads for parallel computation.
  * @param parallel_level Flag indicating whether to use multi-threading (0: serial, 1: parallel).
  *
@@ -122,9 +124,11 @@ std::vector<std::vector<double>> IC4Lattice(const std::vector<double>& source,
                                             const std::vector<size_t>& pred_indices,
                                             const std::vector<int>& E,
                                             const std::vector<int>& b,
-                                            int tau,
-                                            int exclude,
-                                            int threads,
-                                            int parallel_level);
+                                            int tau = 1,
+                                            int exclude = 0,
+                                            int style = 1,
+                                            int dist_metric = 2,
+                                            int threads = 8,
+                                            int parallel_level = 0);
 
 #endif // Forecast4Lattice_H

--- a/src/ForecastExp.cpp
+++ b/src/ForecastExp.cpp
@@ -170,6 +170,7 @@ Rcpp::NumericVector RcppSMapForecast(
  *   pred: An IntegerVector containing the prediction indices. These are 1-based indices in R, and will be converted to 0-based indices in C++.
  *   num_neighbors: An integer specifying the number of neighbors to use for cross mapping.
  *   n_excluded: An integer indicating the number of neighbors to exclude from the distance matrix.
+ *   dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
  *   threads: The number of parallel threads to use for computation.
  *   parallel_level: Whether to use multithreaded (0) or serial (1) mode
  *
@@ -184,6 +185,7 @@ Rcpp::NumericVector RcppIntersectionCardinality(
     const Rcpp::IntegerVector& pred,
     const int& num_neighbors = 4,
     const int& n_excluded = 0,
+    const int& dist_metric = 2,
     const int& threads = 8,
     const int& parallel_level = 0){
   // Convert Rcpp NumericMatrix to std::vector<std::vector<double>>
@@ -233,6 +235,7 @@ Rcpp::NumericVector RcppIntersectionCardinality(
     pred_indices,
     static_cast<size_t>(num_neighbors),
     static_cast<size_t>(n_excluded),
+    dist_metric,
     threads,
     parallel_level
   );

--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -885,6 +885,8 @@ Rcpp::NumericMatrix RcppIC4Grid(const Rcpp::NumericMatrix& source,
                                 const Rcpp::IntegerVector& b,
                                 int tau = 1,
                                 int exclude = 0,
+                                int style = 1,
+                                int dist_metric = 2,
                                 int threads = 8,
                                 int parallel_level = 0) {
   // Convert Rcpp::NumericMatrix to std::vector<std::vector<double>>
@@ -973,6 +975,8 @@ Rcpp::NumericMatrix RcppIC4Grid(const Rcpp::NumericMatrix& source,
     b_std,
     tau,
     exclude,
+    style,
+    dist_metric,
     threads,
     parallel_level);
 

--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -1420,8 +1420,10 @@ Rcpp::List RcppGCMC4Grid(
     const Rcpp::IntegerMatrix& pred,
     const Rcpp::IntegerVector& E,
     const Rcpp::IntegerVector& tau,
-    int b,
+    int b = 4,
     int r = 0,
+    int style = 1,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = false){
@@ -1516,13 +1518,13 @@ Rcpp::List RcppGCMC4Grid(
   }
 
   // Generate embeddings
-  std::vector<std::vector<double>> e1 = GenGridEmbeddings(xMatrix_cpp, E[0], tau_std[0]);
-  std::vector<std::vector<double>> e2 = GenGridEmbeddings(yMatrix_cpp, E[1], tau_std[1]);
+  std::vector<std::vector<double>> e1 = GenGridEmbeddings(xMatrix_cpp, E[0], tau_std[0], style);
+  std::vector<std::vector<double>> e2 = GenGridEmbeddings(yMatrix_cpp, E[1], tau_std[1], style);
 
   // Perform GCMC for spatial grid data
   CMCRes res = CrossMappingCardinality(e1,e2,libsizes_std,lib_std,pred_std,
                                        static_cast<size_t>(b),static_cast<size_t>(r),
-                                       threads,parallel_level,progressbar);
+                                       dist_metric,threads,parallel_level,progressbar);
 
   // Convert mean_aucs to Rcpp::DataFrame
   std::vector<double> libs, aucs;

--- a/src/IntersectionCardinality.cpp
+++ b/src/IntersectionCardinality.cpp
@@ -310,6 +310,7 @@ std::vector<IntersectionRes> IntersectionCardinalitySingle(
  * @param pred            Vector of prediction indices (shouble be 0-based in C++).
  * @param num_neighbors   Maximum number of neighbors to consider in intersection (e.g., from 1 to k).
  * @param n_excluded      Number of nearest neighbors to exclude (e.g., due to temporal proximity).
+ * @param dist_metric     Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads         Number of threads used for parallel computation.
  * @param parallel_level  Parallel mode flag: 0 = parallel, 1 = serial.
  *
@@ -331,7 +332,8 @@ std::vector<double> IntersectionCardinality(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0) {
   std::vector<double> result (num_neighbors, std::numeric_limits<double>::quiet_NaN());
   // Input validation
@@ -356,13 +358,16 @@ std::vector<double> IntersectionCardinality(
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
 
+  // Use L1 norm (Manhattan distance) if dist_metric == 1, else use L2 norm
+  bool L1norm = (dist_metric == 1);
+
   // // Precompute neighbors (The earlier implementation based on a serial version)
-  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, false, true), lib, num_neighbors + n_excluded);
-  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, false, true), lib, num_neighbors + n_excluded);
+  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, L1norm, true), lib, num_neighbors + n_excluded);
+  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, L1norm, true), lib, num_neighbors + n_excluded);
 
   // Precompute neighbors (parallel computation)
-  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet);
-  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet);
+  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
+  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
 
   // run cross mapping
   std::vector<IntersectionRes> res = IntersectionCardinalitySingle(
@@ -389,6 +394,7 @@ std::vector<double> IntersectionCardinality(
  *   pred           - Prediction index vector (shouble be 0-based in C++).
  *   num_neighbors  - Number of neighbors used for cross mapping (after exclusion).
  *   n_excluded     - Number of nearest neighbors to exclude (e.g. temporal).
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
  *   threads        - Number of threads used in parallel computation.
  *   parallel_level - Whether to use multithreaded (0) or serial (1) mode
  *
@@ -406,7 +412,8 @@ std::vector<double> IntersectionCardinalityScores(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0) {
   // Input validation
   if (embedding_x.size() != embedding_y.size() || embedding_x.empty()) {
@@ -430,13 +437,16 @@ std::vector<double> IntersectionCardinalityScores(
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
 
+  // Use L1 norm (Manhattan distance) if dist_metric == 1, else use L2 norm
+  bool L1norm = (dist_metric == 1);
+
   // // Precompute neighbors (The earlier implementation based on a serial version)
-  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, false, true), lib, num_neighbors + n_excluded);
-  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, false, true), lib, num_neighbors + n_excluded);
+  // auto nx = CppDistSortedIndice(CppMatDistance(embedding_x, L1norm, true), lib, num_neighbors + n_excluded);
+  // auto ny = CppDistSortedIndice(CppMatDistance(embedding_y, L1norm, true), lib, num_neighbors + n_excluded);
 
   // Precompute neighbors (parallel computation)
-  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet);
-  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet);
+  auto nx = CppMatKNNeighbors(embedding_x, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
+  auto ny = CppMatKNNeighbors(embedding_y, lib, num_neighbors + n_excluded, threads_sizet, L1norm);
 
   // run cross mapping
   std::vector<IntersectionRes> res = IntersectionCardinalitySingle(

--- a/src/IntersectionCardinality.h
+++ b/src/IntersectionCardinality.h
@@ -68,6 +68,7 @@ std::vector<IntersectionRes> IntersectionCardinalitySingle(
  * @param pred            Vector of prediction indices (shouble be 0-based in C++).
  * @param num_neighbors   Maximum number of neighbors to consider in intersection (e.g., from 1 to k).
  * @param n_excluded      Number of nearest neighbors to exclude (e.g., due to temporal proximity).
+ * @param dist_metric     Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads         Number of threads used for parallel computation.
  * @param parallel_level  Parallel mode flag: 0 = parallel, 1 = serial.
  *
@@ -89,7 +90,8 @@ std::vector<double> IntersectionCardinality(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0);
 
 /**
@@ -107,6 +109,7 @@ std::vector<double> IntersectionCardinality(
  *   pred           - Prediction index vector (shouble be 0-based in C++).
  *   num_neighbors  - Number of neighbors used for cross mapping (after exclusion).
  *   n_excluded     - Number of nearest neighbors to exclude (e.g. temporal).
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
  *   threads        - Number of threads used in parallel computation.
  *   parallel_level - Whether to use multithreaded (0) or serial (1) mode
  *
@@ -124,7 +127,8 @@ std::vector<double> IntersectionCardinalityScores(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0);
 
 #endif // IntersectionCardinality_H

--- a/src/LatticeExp.cpp
+++ b/src/LatticeExp.cpp
@@ -811,6 +811,8 @@ Rcpp::NumericMatrix RcppIC4Lattice(const Rcpp::NumericVector& source,
                                    const Rcpp::IntegerVector& b,
                                    int tau = 1,
                                    int exclude = 0,
+                                   int style = 1,
+                                   int dist_metric = 2,
                                    int threads = 8,
                                    int parallel_level = 0) {
   // Convert neighborhood list to std::vector<std::vector<int>>
@@ -867,6 +869,8 @@ Rcpp::NumericMatrix RcppIC4Lattice(const Rcpp::NumericVector& source,
     b_std,
     tau,
     exclude,
+    style,
+    dist_metric,
     threads,
     parallel_level);
 
@@ -1082,8 +1086,10 @@ Rcpp::List RcppGCMC4Lattice(
     const Rcpp::IntegerVector& pred,
     const Rcpp::IntegerVector& E,
     const Rcpp::IntegerVector& tau,
-    int b,
+    int b = 4,
     int r = 0,
+    int style = 1,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = false){
@@ -1128,13 +1134,13 @@ Rcpp::List RcppGCMC4Lattice(
   }
 
   // Generate embeddings
-  std::vector<std::vector<double>> e1 = GenLatticeEmbeddings(x_std, nb_vec, E[0], tau_std[0]);
-  std::vector<std::vector<double>> e2 = GenLatticeEmbeddings(y_std, nb_vec, E[1], tau_std[1]);
+  std::vector<std::vector<double>> e1 = GenLatticeEmbeddings(x_std, nb_vec, E[0], tau_std[0], style);
+  std::vector<std::vector<double>> e2 = GenLatticeEmbeddings(y_std, nb_vec, E[1], tau_std[1], style);
 
   // Perform GCMC for spatial lattice data
   CMCRes res = CrossMappingCardinality(e1,e2,libsizes_std,lib_std,pred_std,
                                        static_cast<size_t>(b),static_cast<size_t>(r),
-                                       threads,parallel_level,progressbar);
+                                       dist_metric,threads,parallel_level,progressbar);
 
   // Convert mean_aucs to Rcpp::DataFrame
   std::vector<double> libs, aucs;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -157,8 +157,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppIntersectionCardinality
-Rcpp::NumericVector RcppIntersectionCardinality(const Rcpp::NumericMatrix& embedding_x, const Rcpp::NumericMatrix& embedding_y, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const int& n_excluded, const int& threads, const int& parallel_level);
-RcppExport SEXP _spEDM_RcppIntersectionCardinality(SEXP embedding_xSEXP, SEXP embedding_ySEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP n_excludedSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
+Rcpp::NumericVector RcppIntersectionCardinality(const Rcpp::NumericMatrix& embedding_x, const Rcpp::NumericMatrix& embedding_y, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const int& n_excluded, const int& dist_metric, const int& threads, const int& parallel_level);
+RcppExport SEXP _spEDM_RcppIntersectionCardinality(SEXP embedding_xSEXP, SEXP embedding_ySEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP n_excludedSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type embedding_x(embedding_xSEXP);
@@ -167,9 +167,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type pred(predSEXP);
     Rcpp::traits::input_parameter< const int& >::type num_neighbors(num_neighborsSEXP);
     Rcpp::traits::input_parameter< const int& >::type n_excluded(n_excludedSEXP);
+    Rcpp::traits::input_parameter< const int& >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< const int& >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< const int& >::type parallel_level(parallel_levelSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppIntersectionCardinality(embedding_x, embedding_y, lib, pred, num_neighbors, n_excluded, threads, parallel_level));
+    rcpp_result_gen = Rcpp::wrap(RcppIntersectionCardinality(embedding_x, embedding_y, lib, pred, num_neighbors, n_excluded, dist_metric, threads, parallel_level));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -396,8 +397,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppIC4Grid
-Rcpp::NumericMatrix RcppIC4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int threads, int parallel_level);
-RcppExport SEXP _spEDM_RcppIC4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
+Rcpp::NumericMatrix RcppIC4Grid(const Rcpp::NumericMatrix& source, const Rcpp::NumericMatrix& target, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int style, int dist_metric, int threads, int parallel_level);
+RcppExport SEXP _spEDM_RcppIC4Grid(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type source(sourceSEXP);
@@ -408,9 +409,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type exclude(excludeSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppIC4Grid(source, target, lib, pred, E, b, tau, exclude, threads, parallel_level));
+    rcpp_result_gen = Rcpp::wrap(RcppIC4Grid(source, target, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -461,8 +464,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppGCMC4Grid
-Rcpp::List RcppGCMC4Grid(const Rcpp::NumericMatrix& xMatrix, const Rcpp::NumericMatrix& yMatrix, const Rcpp::IntegerMatrix& libsizes, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _spEDM_RcppGCMC4Grid(SEXP xMatrixSEXP, SEXP yMatrixSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::List RcppGCMC4Grid(const Rcpp::NumericMatrix& xMatrix, const Rcpp::NumericMatrix& yMatrix, const Rcpp::IntegerMatrix& libsizes, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int style, int dist_metric, int threads, int parallel_level, bool progressbar);
+RcppExport SEXP _spEDM_RcppGCMC4Grid(SEXP xMatrixSEXP, SEXP yMatrixSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type xMatrix(xMatrixSEXP);
@@ -474,10 +477,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type r(rSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppGCMC4Grid(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppGCMC4Grid(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, r, style, dist_metric, threads, parallel_level, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -790,8 +795,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppIC4Lattice
-Rcpp::NumericMatrix RcppIC4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int threads, int parallel_level);
-RcppExport SEXP _spEDM_RcppIC4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
+Rcpp::NumericMatrix RcppIC4Lattice(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::List& nb, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int style, int dist_metric, int threads, int parallel_level);
+RcppExport SEXP _spEDM_RcppIC4Lattice(SEXP sourceSEXP, SEXP targetSEXP, SEXP nbSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type source(sourceSEXP);
@@ -803,9 +808,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type exclude(excludeSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppIC4Lattice(source, target, nb, lib, pred, E, b, tau, exclude, threads, parallel_level));
+    rcpp_result_gen = Rcpp::wrap(RcppIC4Lattice(source, target, nb, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -858,8 +865,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppGCMC4Lattice
-Rcpp::List RcppGCMC4Lattice(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::List& nb, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _spEDM_RcppGCMC4Lattice(SEXP xSEXP, SEXP ySEXP, SEXP nbSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::List RcppGCMC4Lattice(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::List& nb, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int style, int dist_metric, int threads, int parallel_level, bool progressbar);
+RcppExport SEXP _spEDM_RcppGCMC4Lattice(SEXP xSEXP, SEXP ySEXP, SEXP nbSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type x(xSEXP);
@@ -872,10 +879,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type r(rSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppGCMC4Lattice(x, y, nb, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppGCMC4Lattice(x, y, nb, libsizes, lib, pred, E, tau, b, r, style, dist_metric, threads, parallel_level, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1363,15 +1372,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppMatKNNeighbors
-Rcpp::List RcppMatKNNeighbors(const Rcpp::NumericMatrix& embeddings, const Rcpp::IntegerVector& lib, int k, int threads);
-RcppExport SEXP _spEDM_RcppMatKNNeighbors(SEXP embeddingsSEXP, SEXP libSEXP, SEXP kSEXP, SEXP threadsSEXP) {
+Rcpp::List RcppMatKNNeighbors(const Rcpp::NumericMatrix& embeddings, const Rcpp::IntegerVector& lib, int k, int threads, bool L1norm);
+RcppExport SEXP _spEDM_RcppMatKNNeighbors(SEXP embeddingsSEXP, SEXP libSEXP, SEXP kSEXP, SEXP threadsSEXP, SEXP L1normSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type embeddings(embeddingsSEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type lib(libSEXP);
     Rcpp::traits::input_parameter< int >::type k(kSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppMatKNNeighbors(embeddings, lib, k, threads));
+    Rcpp::traits::input_parameter< bool >::type L1norm(L1normSEXP);
+    rcpp_result_gen = Rcpp::wrap(RcppMatKNNeighbors(embeddings, lib, k, threads, L1norm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1433,7 +1443,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppConditionalEntropy_Disc", (DL_FUNC) &_spEDM_RcppConditionalEntropy_Disc, 5},
     {"_spEDM_RcppSimplexForecast", (DL_FUNC) &_spEDM_RcppSimplexForecast, 7},
     {"_spEDM_RcppSMapForecast", (DL_FUNC) &_spEDM_RcppSMapForecast, 8},
-    {"_spEDM_RcppIntersectionCardinality", (DL_FUNC) &_spEDM_RcppIntersectionCardinality, 8},
+    {"_spEDM_RcppIntersectionCardinality", (DL_FUNC) &_spEDM_RcppIntersectionCardinality, 9},
     {"_spEDM_RcppLocateGridIndices", (DL_FUNC) &_spEDM_RcppLocateGridIndices, 4},
     {"_spEDM_RcppRowColFromGrid", (DL_FUNC) &_spEDM_RcppRowColFromGrid, 2},
     {"_spEDM_RcppLaggedVal4Grid", (DL_FUNC) &_spEDM_RcppLaggedVal4Grid, 2},
@@ -1448,10 +1458,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSimplex4Grid", (DL_FUNC) &_spEDM_RcppSimplex4Grid, 11},
     {"_spEDM_RcppSMap4Grid", (DL_FUNC) &_spEDM_RcppSMap4Grid, 12},
     {"_spEDM_RcppMultiView4Grid", (DL_FUNC) &_spEDM_RcppMultiView4Grid, 13},
-    {"_spEDM_RcppIC4Grid", (DL_FUNC) &_spEDM_RcppIC4Grid, 10},
+    {"_spEDM_RcppIC4Grid", (DL_FUNC) &_spEDM_RcppIC4Grid, 12},
     {"_spEDM_RcppGCCM4Grid", (DL_FUNC) &_spEDM_RcppGCCM4Grid, 13},
     {"_spEDM_RcppSCPCM4Grid", (DL_FUNC) &_spEDM_RcppSCPCM4Grid, 15},
-    {"_spEDM_RcppGCMC4Grid", (DL_FUNC) &_spEDM_RcppGCMC4Grid, 12},
+    {"_spEDM_RcppGCMC4Grid", (DL_FUNC) &_spEDM_RcppGCMC4Grid, 14},
     {"_spEDM_RcppSGCSingle4Grid", (DL_FUNC) &_spEDM_RcppSGCSingle4Grid, 8},
     {"_spEDM_RcppSGC4Grid", (DL_FUNC) &_spEDM_RcppSGC4Grid, 13},
     {"_spEDM_DetectMaxNumThreads", (DL_FUNC) &_spEDM_DetectMaxNumThreads, 0},
@@ -1472,10 +1482,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSimplex4Lattice", (DL_FUNC) &_spEDM_RcppSimplex4Lattice, 12},
     {"_spEDM_RcppSMap4Lattice", (DL_FUNC) &_spEDM_RcppSMap4Lattice, 13},
     {"_spEDM_RcppMultiView4Lattice", (DL_FUNC) &_spEDM_RcppMultiView4Lattice, 14},
-    {"_spEDM_RcppIC4Lattice", (DL_FUNC) &_spEDM_RcppIC4Lattice, 11},
+    {"_spEDM_RcppIC4Lattice", (DL_FUNC) &_spEDM_RcppIC4Lattice, 13},
     {"_spEDM_RcppGCCM4Lattice", (DL_FUNC) &_spEDM_RcppGCCM4Lattice, 14},
     {"_spEDM_RcppSCPCM4Lattice", (DL_FUNC) &_spEDM_RcppSCPCM4Lattice, 16},
-    {"_spEDM_RcppGCMC4Lattice", (DL_FUNC) &_spEDM_RcppGCMC4Lattice, 13},
+    {"_spEDM_RcppGCMC4Lattice", (DL_FUNC) &_spEDM_RcppGCMC4Lattice, 15},
     {"_spEDM_RcppSGCSingle4Lattice", (DL_FUNC) &_spEDM_RcppSGCSingle4Lattice, 9},
     {"_spEDM_RcppSGC4Lattice", (DL_FUNC) &_spEDM_RcppSGC4Lattice, 14},
     {"_spEDM_RcppFactorial", (DL_FUNC) &_spEDM_RcppFactorial, 1},
@@ -1515,7 +1525,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppKNNIndice", (DL_FUNC) &_spEDM_RcppKNNIndice, 4},
     {"_spEDM_RcppDistKNNIndice", (DL_FUNC) &_spEDM_RcppDistKNNIndice, 4},
     {"_spEDM_RcppDistSortedIndice", (DL_FUNC) &_spEDM_RcppDistSortedIndice, 4},
-    {"_spEDM_RcppMatKNNeighbors", (DL_FUNC) &_spEDM_RcppMatKNNeighbors, 4},
+    {"_spEDM_RcppMatKNNeighbors", (DL_FUNC) &_spEDM_RcppMatKNNeighbors, 5},
     {"_spEDM_RcppLinearTrendRM", (DL_FUNC) &_spEDM_RcppLinearTrendRM, 4},
     {"_spEDM_RcppSVD", (DL_FUNC) &_spEDM_RcppSVD, 1},
     {"_spEDM_RcppDeLongPlacements", (DL_FUNC) &_spEDM_RcppDeLongPlacements, 3},

--- a/src/StatsExp.cpp
+++ b/src/StatsExp.cpp
@@ -573,7 +573,7 @@ Rcpp::List RcppDistSortedIndice(const Rcpp::NumericMatrix& dist_mat,
 // [[Rcpp::export(rng = false)]]
 Rcpp::List RcppMatKNNeighbors(const Rcpp::NumericMatrix& embeddings,
                               const Rcpp::IntegerVector& lib,
-                              int k, int threads = 8) {
+                              int k, int threads = 8, bool L1norm = false) {
   // Get number of rows and columns
   const int n = embeddings.nrow();
   const int m = embeddings.ncol();
@@ -592,7 +592,7 @@ Rcpp::List RcppMatKNNeighbors(const Rcpp::NumericMatrix& embeddings,
   }
 
   // Call the existing C++ function to compute sorted neighbor indices
-  std::vector<std::vector<size_t>> result = CppMatKNNeighbors(emb, lib_std, static_cast<size_t>(k), static_cast<size_t>(threads));
+  std::vector<std::vector<size_t>> result = CppMatKNNeighbors(emb, lib_std, static_cast<size_t>(k), static_cast<size_t>(threads), L1norm);
 
   // Convert the result to an R list of integer vectors
   Rcpp::List out(n);


### PR DESCRIPTION
New `style` and `dist.metric` parameters in `ic` and `gcmc` generics, see #755 for more details