### PR TITLE
synchronize support for independent metric selection and embedding styles in cross mapping

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -105,8 +105,8 @@ RcppIC4Grid <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L,
     .Call(`_spEDM_RcppIC4Grid`, source, target, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level)
 }
 
-RcppGCCM4Grid <- function(xMatrix, yMatrix, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_spEDM_RcppGCCM4Grid`, xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar)
+RcppGCCM4Grid <- function(xMatrix, yMatrix, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, style = 1L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
+    .Call(`_spEDM_RcppGCCM4Grid`, xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, style, dist_metric, dist_average, progressbar)
 }
 
 RcppSCPCM4Grid <- function(xMatrix, yMatrix, zMatrix, libsizes, lib, pred, E, tau, b, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, cumulate = FALSE, style = 1L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
@@ -201,8 +201,8 @@ RcppIC4Lattice <- function(source, target, nb, lib, pred, E, b, tau = 1L, exclud
     .Call(`_spEDM_RcppIC4Lattice`, source, target, nb, lib, pred, E, b, tau, exclude, style, dist_metric, threads, parallel_level)
 }
 
-RcppGCCM4Lattice <- function(x, y, nb, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_spEDM_RcppGCCM4Lattice`, x, y, nb, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar)
+RcppGCCM4Lattice <- function(x, y, nb, libsizes, lib, pred, E = 3L, tau = 1L, b = 5L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, style = 1L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
+    .Call(`_spEDM_RcppGCCM4Lattice`, x, y, nb, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, style, dist_metric, dist_average, progressbar)
 }
 
 RcppSCPCM4Lattice <- function(x, y, z, nb, libsizes, lib, pred, E, tau, b, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, cumulate = FALSE, style = 1L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {

--- a/R/gccm.R
+++ b/R/gccm.R
@@ -1,5 +1,5 @@
-.gccm_sf_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL,
-                    nb = NULL,threads = detectThreads(),parallel.level = "low",bidirectional = TRUE,detrend = TRUE,progressbar = TRUE){
+.gccm_sf_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL, style = 1, dist.metric = "L2",
+                    dist.average = TRUE, nb = NULL, threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = TRUE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -25,15 +25,17 @@
   simplex = ifelse(algorithm == "simplex", TRUE, FALSE)
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppGCCM4Lattice(cause,effect,nb,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,pl,progressbar)
+    x_xmap_y = RcppGCCM4Lattice(cause,effect,nb,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,
+                                pl, style, .check_distmetric(dist.metric), dist.average, progressbar)
   }
-  y_xmap_x = RcppGCCM4Lattice(effect,cause,nb,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,pl,progressbar)
+  y_xmap_x = RcppGCCM4Lattice(effect,cause,nb,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,
+                              pl, style, .check_distmetric(dist.metric), dist.average,progressbar)
 
   return(.bind_xmapdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
 
-.gccm_spatraster_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL,
-                            threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = TRUE, progressbar = TRUE){
+.gccm_spatraster_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = E+2, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL, style = 1, dist.metric = "L2",
+                            dist.average = TRUE, threads = detectThreads(), parallel.level = "low", bidirectional = TRUE, detrend = TRUE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -57,9 +59,11 @@
   simplex = ifelse(algorithm == "simplex", TRUE, FALSE)
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppGCCM4Grid(causemat,effectmat,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,pl,progressbar)
+    x_xmap_y = RcppGCCM4Grid(causemat,effectmat,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,
+                             pl, style, .check_distmetric(dist.metric), dist.average, progressbar)
   }
-  y_xmap_x = RcppGCCM4Grid(effectmat,causemat,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,pl,progressbar)
+  y_xmap_x = RcppGCCM4Grid(effectmat,causemat,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,
+                           pl, style, .check_distmetric(dist.metric), dist.average, progressbar)
 
   return(.bind_xmapdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
@@ -69,6 +73,7 @@
 #' @inheritParams gcmc
 #' @param theta (optional) weighting parameter for distances, useful when `algorithm` is `smap`.
 #' @param algorithm (optional) prediction algorithm.
+#' @param dist.average (optional) whether to average distance.
 #'
 #' @return A list
 #' \describe{

--- a/man/gccm.Rd
+++ b/man/gccm.Rd
@@ -18,6 +18,9 @@
   algorithm = "simplex",
   lib = NULL,
   pred = NULL,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   nb = NULL,
   threads = detectThreads(),
   parallel.level = "low",
@@ -38,6 +41,9 @@
   algorithm = "simplex",
   lib = NULL,
   pred = NULL,
+  style = 1,
+  dist.metric = "L2",
+  dist.average = TRUE,
   threads = detectThreads(),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -67,6 +73,12 @@
 \item{lib}{(optional) libraries indices.}
 
 \item{pred}{(optional) predictions indices.}
+
+\item{style}{(optional) embedding style (\code{0} includes current state, \code{1} excludes it).}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{nb}{(optional) neighbours list.}
 

--- a/src/GCCM4Grid.cpp
+++ b/src/GCCM4Grid.cpp
@@ -32,6 +32,8 @@
  * @param threads              The number of threads to use for parallel processing.
  * @param parallel_level       Level of parallel computing: 0 for `lower`, 1 for `higher`.
  * @param row_size_mark        If true, use the row-wise libsize to mark the libsize; if false, use col-wise libsize.
+ * @param dist_metric          Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average         Whether to average distance by the number of valid vector components.
  *
  * @return  A vector of pairs, where each pair contains the library size and the corresponding cross mapping result.
  */
@@ -48,7 +50,9 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
     double theta,
     size_t threads,
     int parallel_level,
-    bool row_size_mark) {
+    bool row_size_mark,
+    int dist_metric,
+    bool dist_average) {
   // Extract row-wise and column-wise library sizes
   const int lib_size_row = lib_sizes[0];
   const int lib_size_col = lib_sizes[1];
@@ -91,9 +95,9 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
     double rho = std::numeric_limits<double>::quiet_NaN();
     // Run cross map and store results
     if (simplex) {
-      rho = SimplexProjection(xEmbedings, yPred, lib_indices, pred_indices, b);
+      rho = SimplexProjection(xEmbedings, yPred, lib_indices, pred_indices, b, dist_metric, dist_average);
     } else {
-      rho = SMap(xEmbedings, yPred, lib_indices, pred_indices, b, theta);
+      rho = SMap(xEmbedings, yPred, lib_indices, pred_indices, b, theta, dist_metric, dist_average);
     }
     x_xmap_y[idx] = std::make_pair(libsize, rho);
   };
@@ -128,6 +132,8 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
  * @param theta                Distance weighting parameter for S-mapping
  * @param threads              The number of threads to use for parallel processing
  * @param parallel_level       Level of parallel computing: 0 for `lower`, 1 for `higher`
+ * @param dist_metric          Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average         Whether to average distance by the number of valid vector components.
  *
  * @return A vector of pairs, where each pair contains the library size and the corresponding cross mapping result.
  */
@@ -143,7 +149,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
     bool simplex,
     double theta,
     size_t threads,
-    int parallel_level) {
+    int parallel_level,
+    int dist_metric,
+    bool dist_average) {
   int max_lib_size = lib_indices.size();
 
   // No possible library variation if using all vectors
@@ -153,9 +161,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
     double rho = std::numeric_limits<double>::quiet_NaN();
     // Run cross map and store results
     if (simplex) {
-      rho = SimplexProjection(xEmbedings, yPred, lib_indices, pred_indices, b);
+      rho = SimplexProjection(xEmbedings, yPred, lib_indices, pred_indices, b, dist_metric, dist_average);
     } else {
-      rho = SMap(xEmbedings, yPred, lib_indices, pred_indices, b, theta);
+      rho = SMap(xEmbedings, yPred, lib_indices, pred_indices, b, theta, dist_metric, dist_average);
     }
     x_xmap_y.emplace_back(lib_size, rho);
     return x_xmap_y;
@@ -189,9 +197,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
       double rho = std::numeric_limits<double>::quiet_NaN();
       // Run cross map and store results
       if (simplex) {
-        rho = SimplexProjection(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b);
+        rho = SimplexProjection(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, dist_metric, dist_average);
       } else {
-        rho = SMap(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, theta);
+        rho = SMap(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, theta, dist_metric, dist_average);
       }
 
       std::pair<int, double> result(lib_size, rho); // Store the product of row and column library sizes
@@ -229,9 +237,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
       double rho = std::numeric_limits<double>::quiet_NaN();
       // Run cross map and store results
       if (simplex) {
-        rho = SimplexProjection(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b);
+        rho = SimplexProjection(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, dist_metric, dist_average);
       } else {
-        rho = SMap(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, theta);
+        rho = SMap(xEmbedings, yPred, valid_lib_indices[i], pred_indices, b, theta, dist_metric, dist_average);
       }
 
       std::pair<int, double> result(lib_size, rho); // Store the product of row and column library sizes
@@ -260,6 +268,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
  * @param theta          The distance weighting parameter for S-Mapping (ignored if simplex is true).
  * @param threads        The number of threads to use for parallel processing.
  * @param parallel_level Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * @param style          Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric    Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average   Whether to average distance by the number of valid vector components.
  * @param progressbar    If true, display a progress bar during computation.
  *
  * @return A 2D vector where each row contains the library size, mean cross mapping result,
@@ -278,6 +289,9 @@ std::vector<std::vector<double>> GCCM4Grid(
     double theta,
     int threads,
     int parallel_level,
+    int style,
+    int dist_metric,
+    bool dist_average,
     bool progressbar
 ) {
   // If b is not provided correctly, default it to E + 2
@@ -300,7 +314,7 @@ std::vector<std::vector<double>> GCCM4Grid(
   }
 
   // Generate embeddings for xMatrix
-  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, E, tau);
+  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, E, tau, style);
 
   // Ensure the maximum value does not exceed totalRow or totalCol
   int max_lib_size_row = totalRow;
@@ -394,7 +408,9 @@ std::vector<std::vector<double>> GCCM4Grid(
           theta,
           threads_sizet,
           parallel_level,
-          row_size_mark);
+          row_size_mark,
+          dist_metric,
+          dist_average);
         bar++;
       }
     } else {
@@ -414,7 +430,9 @@ std::vector<std::vector<double>> GCCM4Grid(
           theta,
           threads_sizet,
           parallel_level,
-          row_size_mark);
+          row_size_mark,
+          dist_metric,
+          dist_average);
       }
     }
   } else {
@@ -437,7 +455,9 @@ std::vector<std::vector<double>> GCCM4Grid(
           theta,
           threads_sizet,
           parallel_level,
-          row_size_mark);
+          row_size_mark,
+          dist_metric,
+          dist_average);
         bar++;
       }, threads_sizet);
     } else {
@@ -457,7 +477,9 @@ std::vector<std::vector<double>> GCCM4Grid(
           theta,
           threads_sizet,
           parallel_level,
-          row_size_mark);
+          row_size_mark,
+          dist_metric,
+          dist_average);
       }, threads_sizet);
     }
   }
@@ -540,6 +562,9 @@ std::vector<std::vector<double>> GCCM4Grid(
  * @param theta          The distance weighting parameter for S-Mapping (ignored if simplex is true).
  * @param threads        The number of threads to use for parallel processing.
  * @param parallel_level Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * @param style          Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric    Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average   Whether to average distance by the number of valid vector components.
  * @param progressbar    If true, display a progress bar during computation.
  *
  * @return A 2D vector where each row contains the library size, mean cross mapping result,
@@ -558,6 +583,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
     double theta,
     int threads,
     int parallel_level,
+    int style,
+    int dist_metric,
+    bool dist_average,
     bool progressbar
 ) {
   // If b is not provided correctly, default it to E + 2
@@ -580,7 +608,7 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
   }
 
   // Generate embeddings for xMatrix
-  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, E, tau);
+  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, E, tau, style);
 
   int max_lib_size = static_cast<int>(lib.size()); // Maximum lib size
 
@@ -618,7 +646,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
           simplex,
           theta,
           threads_sizet,
-          parallel_level
+          parallel_level,
+          dist_metric,
+          dist_average
         );
         bar++;
       }
@@ -636,7 +666,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
           simplex,
           theta,
           threads_sizet,
-          parallel_level
+          parallel_level,
+          dist_metric,
+          dist_average
         );
       }
     }
@@ -658,7 +690,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
           simplex,
           theta,
           threads_sizet,
-          parallel_level
+          parallel_level,
+          dist_metric,
+          dist_average
         );
         bar++;
       }, threads_sizet);
@@ -677,7 +711,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
           simplex,
           theta,
           threads_sizet,
-          parallel_level
+          parallel_level,
+          dist_metric,
+          dist_average
         );
       }, threads_sizet);
     }

--- a/src/GCCM4Grid.cpp
+++ b/src/GCCM4Grid.cpp
@@ -52,7 +52,8 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
     int parallel_level,
     bool row_size_mark,
     int dist_metric,
-    bool dist_average) {
+    bool dist_average
+) {
   // Extract row-wise and column-wise library sizes
   const int lib_size_row = lib_sizes[0];
   const int lib_size_col = lib_sizes[1];
@@ -151,7 +152,8 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
     size_t threads,
     int parallel_level,
     int dist_metric,
-    bool dist_average) {
+    bool dist_average
+) {
   int max_lib_size = lib_indices.size();
 
   // No possible library variation if using all vectors

--- a/src/GCCM4Grid.h
+++ b/src/GCCM4Grid.h
@@ -33,6 +33,8 @@
  * @param threads              The number of threads to use for parallel processing.
  * @param parallel_level       Level of parallel computing: 0 for `lower`, 1 for `higher`.
  * @param row_size_mark        If true, use the row-wise libsize to mark the libsize; if false, use col-wise libsize.
+ * @param dist_metric          Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average         Whether to average distance by the number of valid vector components.
  *
  * @return  A vector of pairs, where each pair contains the library size and the corresponding cross mapping result.
  */
@@ -49,7 +51,9 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
     double theta,
     size_t threads,
     int parallel_level,
-    bool row_size_mark
+    bool row_size_mark,
+    int dist_metric,
+    bool dist_average
 );
 
 /**
@@ -70,6 +74,8 @@ std::vector<std::pair<int, double>> GCCMSingle4Grid(
  * @param theta                Distance weighting parameter for S-mapping
  * @param threads              The number of threads to use for parallel processing
  * @param parallel_level       Level of parallel computing: 0 for `lower`, 1 for `higher`
+ * @param dist_metric          Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average         Whether to average distance by the number of valid vector components.
  *
  * @return A vector of pairs, where each pair contains the library size and the corresponding cross mapping result.
  */
@@ -85,7 +91,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
     bool simplex,
     double theta,
     size_t threads,
-    int parallel_level
+    int parallel_level,
+    int dist_metric,
+    bool dist_average
 );
 
 /**
@@ -106,6 +114,9 @@ std::vector<std::pair<int, double>> GCCMSingle4GridOneDim(
  * @param theta          The distance weighting parameter for S-Mapping (ignored if simplex is true).
  * @param threads        The number of threads to use for parallel processing.
  * @param parallel_level Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * @param style          Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric    Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average   Whether to average distance by the number of valid vector components.
  * @param progressbar    If true, display a progress bar during computation.
  *
  * @return A 2D vector where each row contains the library size, mean cross mapping result,
@@ -124,6 +135,9 @@ std::vector<std::vector<double>> GCCM4Grid(
     double theta,
     int threads,
     int parallel_level,
+    int style,
+    int dist_metric,
+    bool dist_average,
     bool progressbar
 );
 
@@ -145,6 +159,9 @@ std::vector<std::vector<double>> GCCM4Grid(
  * @param theta          The distance weighting parameter for S-Mapping (ignored if simplex is true).
  * @param threads        The number of threads to use for parallel processing.
  * @param parallel_level Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * @param style          Embedding style selector (0: includes current state, 1: excludes it). 
+ * @param dist_metric    Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average   Whether to average distance by the number of valid vector components.
  * @param progressbar    If true, display a progress bar during computation.
  *
  * @return A 2D vector where each row contains the library size, mean cross mapping result,
@@ -163,6 +180,9 @@ std::vector<std::vector<double>> GCCM4GridOneDim(
     double theta,
     int threads,
     int parallel_level,
+    int style,
+    int dist_metric,
+    bool dist_average,
     bool progressbar
 );
 

--- a/src/GCCM4Lattice.h
+++ b/src/GCCM4Lattice.h
@@ -28,6 +28,8 @@
  *   - theta: Distance weighting parameter for local neighbors in the manifold (used in s-mapping).
  *   - threads: The number of threads to use for parallel processing.
  *   - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of pairs, where each pair consists of:
@@ -44,7 +46,9 @@ std::vector<std::pair<int, double>> GCCMSingle4Lattice(
     bool simplex,
     double theta,
     size_t threads,
-    int parallel_level
+    int parallel_level,
+    int dist_metric,
+    bool dist_average
 );
 
 /**
@@ -64,6 +68,9 @@ std::vector<std::pair<int, double>> GCCMSingle4Lattice(
  * - theta: Distance weighting parameter used for weighting neighbors in the S-mapping prediction.
  * - threads: Number of threads to use for parallel computation.
  * - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * - style: Embedding style selector (0: includes current state, 1: excludes it).
+ * - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * - dist_average: Whether to average distance by the number of valid vector components.
  * - progressbar: Boolean flag to indicate whether to display a progress bar during computation.
  *
  * Returns:
@@ -88,6 +95,9 @@ std::vector<std::vector<double>> GCCM4Lattice(
     double theta,
     int threads,
     int parallel_level,
+    int style,
+    int dist_metric,
+    bool dist_average,
     bool progressbar
 );
 

--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -1018,6 +1018,9 @@ Rcpp::NumericMatrix RcppGCCM4Grid(
     double theta = 0,
     int threads = 8,
     int parallel_level = 0,
+    int style = 1,
+    int dist_metric = 2,
+    bool dist_average = true,
     bool progressbar = false) {
   int numRows = yMatrix.nrow();
   int numCols = yMatrix.ncol();
@@ -1161,6 +1164,9 @@ Rcpp::NumericMatrix RcppGCCM4Grid(
       theta,
       threads,
       parallel_level,
+      style,
+      dist_metric,
+      dist_average,
       progressbar
     );
   } else{
@@ -1177,6 +1183,9 @@ Rcpp::NumericMatrix RcppGCCM4Grid(
       theta,
       threads,
       parallel_level,
+      style,
+      dist_metric,
+      dist_average,
       progressbar
     );
   }

--- a/src/LatticeExp.cpp
+++ b/src/LatticeExp.cpp
@@ -913,6 +913,9 @@ Rcpp::NumericMatrix RcppGCCM4Lattice(const Rcpp::NumericVector& x,
                                      double theta = 0,
                                      int threads = 8,
                                      int parallel_level = 0,
+                                     int style = 1,
+                                     int dist_metric = 2,
+                                     bool dist_average = true,
                                      bool progressbar = false) {
   // Convert Rcpp::NumericVector to std::vector<double>
   std::vector<double> x_std = Rcpp::as<std::vector<double>>(x);
@@ -960,6 +963,9 @@ Rcpp::NumericMatrix RcppGCCM4Lattice(const Rcpp::NumericVector& x,
     theta,
     threads,
     parallel_level,
+    style,
+    dist_metric,
+    dist_average,
     progressbar);
 
   // Convert std::vector<std::vector<double>> to Rcpp::NumericMatrix

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -420,8 +420,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppGCCM4Grid
-Rcpp::NumericMatrix RcppGCCM4Grid(const Rcpp::NumericMatrix& xMatrix, const Rcpp::NumericMatrix& yMatrix, const Rcpp::IntegerMatrix& libsizes, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _spEDM_RcppGCCM4Grid(SEXP xMatrixSEXP, SEXP yMatrixSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::NumericMatrix RcppGCCM4Grid(const Rcpp::NumericMatrix& xMatrix, const Rcpp::NumericMatrix& yMatrix, const Rcpp::IntegerMatrix& libsizes, const Rcpp::IntegerMatrix& lib, const Rcpp::IntegerMatrix& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, int style, int dist_metric, bool dist_average, bool progressbar);
+RcppExport SEXP _spEDM_RcppGCCM4Grid(SEXP xMatrixSEXP, SEXP yMatrixSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type xMatrix(xMatrixSEXP);
@@ -436,8 +436,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type theta(thetaSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppGCCM4Grid(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppGCCM4Grid(xMatrix, yMatrix, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, style, dist_metric, dist_average, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -824,8 +827,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppGCCM4Lattice
-Rcpp::NumericMatrix RcppGCCM4Lattice(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::List& nb, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _spEDM_RcppGCCM4Lattice(SEXP xSEXP, SEXP ySEXP, SEXP nbSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::NumericMatrix RcppGCCM4Lattice(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::List& nb, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, int style, int dist_metric, bool dist_average, bool progressbar);
+RcppExport SEXP _spEDM_RcppGCCM4Lattice(SEXP xSEXP, SEXP ySEXP, SEXP nbSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP styleSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type x(xSEXP);
@@ -841,8 +844,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type theta(thetaSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
+    Rcpp::traits::input_parameter< int >::type style(styleSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppGCCM4Lattice(x, y, nb, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppGCCM4Lattice(x, y, nb, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, style, dist_metric, dist_average, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1469,7 +1475,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSMap4Grid", (DL_FUNC) &_spEDM_RcppSMap4Grid, 12},
     {"_spEDM_RcppMultiView4Grid", (DL_FUNC) &_spEDM_RcppMultiView4Grid, 13},
     {"_spEDM_RcppIC4Grid", (DL_FUNC) &_spEDM_RcppIC4Grid, 12},
-    {"_spEDM_RcppGCCM4Grid", (DL_FUNC) &_spEDM_RcppGCCM4Grid, 13},
+    {"_spEDM_RcppGCCM4Grid", (DL_FUNC) &_spEDM_RcppGCCM4Grid, 16},
     {"_spEDM_RcppSCPCM4Grid", (DL_FUNC) &_spEDM_RcppSCPCM4Grid, 18},
     {"_spEDM_RcppGCMC4Grid", (DL_FUNC) &_spEDM_RcppGCMC4Grid, 14},
     {"_spEDM_RcppSGCSingle4Grid", (DL_FUNC) &_spEDM_RcppSGCSingle4Grid, 8},
@@ -1493,7 +1499,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_spEDM_RcppSMap4Lattice", (DL_FUNC) &_spEDM_RcppSMap4Lattice, 13},
     {"_spEDM_RcppMultiView4Lattice", (DL_FUNC) &_spEDM_RcppMultiView4Lattice, 14},
     {"_spEDM_RcppIC4Lattice", (DL_FUNC) &_spEDM_RcppIC4Lattice, 13},
-    {"_spEDM_RcppGCCM4Lattice", (DL_FUNC) &_spEDM_RcppGCCM4Lattice, 14},
+    {"_spEDM_RcppGCCM4Lattice", (DL_FUNC) &_spEDM_RcppGCCM4Lattice, 17},
     {"_spEDM_RcppSCPCM4Lattice", (DL_FUNC) &_spEDM_RcppSCPCM4Lattice, 19},
     {"_spEDM_RcppGCMC4Lattice", (DL_FUNC) &_spEDM_RcppGCMC4Lattice, 15},
     {"_spEDM_RcppSGCSingle4Lattice", (DL_FUNC) &_spEDM_RcppSGCSingle4Lattice, 9},

--- a/src/SCPCM4Grid.cpp
+++ b/src/SCPCM4Grid.cpp
@@ -549,7 +549,7 @@ std::vector<std::vector<double>> SCPCM4Grid(
   }
 
   // Generate embeddings for xMatrix
-  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, Ex, taux);
+  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, Ex, taux, style);
 
   size_t n_confounds;
   if (cumulate){
@@ -930,7 +930,7 @@ std::vector<std::vector<double>> SCPCM4GridOneDim(
   }
 
   // Generate embeddings for xMatrix
-  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, Ex, taux);
+  std::vector<std::vector<double>> xEmbedings = GenGridEmbeddings(xMatrix, Ex, taux, style);
 
   size_t n_confounds;
   if (cumulate){

--- a/src/SCPCM4Lattice.cpp
+++ b/src/SCPCM4Lattice.cpp
@@ -397,7 +397,7 @@ std::vector<std::vector<double>> SCPCM4Lattice(
   size_t threads_sizet = static_cast<size_t>(std::abs(threads));
   threads_sizet = std::min(static_cast<size_t>(std::thread::hardware_concurrency()), threads_sizet);
 
-  std::vector<std::vector<double>> x_vectors = GenLatticeEmbeddings(x,nb_vec,Ex,taux);
+  std::vector<std::vector<double>> x_vectors = GenLatticeEmbeddings(x,nb_vec,Ex,taux,style);
   size_t n = pred.size();
 
   size_t n_confounds;


### PR DESCRIPTION
Introduce `style` `dist.metric` `dist.average` for the `gccm` generic: