### PR TITLE
update configuration to leverage newer armadillo functionality provided by rcpparmadillo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # spEDM 1.9
 
+### enhancements
+
+* Adjust `Makevars` to track latest rcpparmadillo release and armadillo updates improving build integration and forward compatibility (#785).
+
+
+
 # spEDM 1.8
 
 ### new

--- a/src/Makevars
+++ b/src/Makevars
@@ -4,6 +4,6 @@
 
 #PKG_LIBS = `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`
 
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
+PKG_CXXFLAGS = -DARMA_USE_CURRENT
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
            `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,6 +4,6 @@
 
 #PKG_LIBS = `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`
 
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
+PKG_CXXFLAGS = -DARMA_USE_CURRENT
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
            `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`


### PR DESCRIPTION
Adjust `Makevars` to track latest rcpparmadillo release and armadillo updates improving build integration and forward compatibility.