### PR TITLE
correct 3d embedding stacking in multiview embedding forecasting

### DIFF
--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <cmath>
 #include <string>
+#include <iterator>
 #include <algorithm>
 #include "CppStats.h"
 #include "CppGridUtils.h"


### PR DESCRIPTION
This PR updates the stacking behavior of multi-variable lattice embeddings in the 3D embedding mode (`stack != 0`).
Previously, embeddings from each variable were concatenated using:

```cpp
stacked_vec.insert(
    stacked_vec.end(),
    std::make_move_iterator(embedding.begin()),
    std::make_move_iterator(embedding.end())
);
```

This incorrectly **expanded the outer dimension** (number of embedding subsets), rather than **stacking values as additional columns** for the same embeddings.

#### What was wrong

* The result changed the number of embedding subsets (`nb_vec`)
* The shape became inconsistent and meaningless for MultiViewEmbedding
* It broke alignment between embedding subsets and target time series rows

#### What this PR does

✔ Keeps the number of embedding subsets constant
✔ Correctly concatenates embeddings **column-wise**
✔ Maintains row alignment across variables
✔ Uses move iterators for efficient memory operations

#### New stacking behavior

```
stacked_vec[embedding_subset][row][columns across all variables]
```

If a single embedding block is shaped:

```
[nb_vec][num_row][cols_per_var]
```

Then final shape becomes:

```
[nb_vec][num_row][cols_per_var * num_var]
```

#### Key code implementation

```cpp
// Initialize stacked_vec using variable 0
stacked_vec = std::move(first_embedding);

// Column-wise append from variable 1..num_var-1
for (...) {
    for (size_t j = 0; j < stacked_vec.size(); ++j)
        for (size_t r = 0; r < stacked_vec[j].size(); ++r)
            stacked_vec[j][r].insert(
                stacked_vec[j][r].end(),
                std::make_move_iterator(embedding[j][r].begin()),
                std::make_move_iterator(embedding[j][r].end())
            );
}
```

#### Impact

* ✅ Fixes incorrect embedding structure in stacked mode
* ✅ Improves downstream reconstruction accuracy
* ✅ Memory-efficient (move instead of deep copy)
* 🔁 Maintains backward-compatible API surface
