### PR TITLE
fix incorrect grid embedding stacking: switch to column-wise merge and preserve embedding dimension

### DIFF
--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -1004,21 +1004,43 @@ Rcpp::NumericMatrix RcppMultiView4Grid(const Rcpp::NumericMatrix& xMatrix,
       b, k, dist_metric, dist_average, threads);
 
   } else {  // ---- CASE 2: stacked 3D embedding (stack != 0) ----
+    // stacked_vec will store embeddings stacked along the column dimension.
+    // Structure: stacked_vec[embedding_dimension][row][col]
     std::vector<std::vector<std::vector<double>>> stacked_vec;
-    stacked_vec.reserve(num_var);
 
-    for (int n = 0; n < num_var; ++n) {
+    // Initialize stacked_vec based on the first variable's shape
+    {
+      std::vector<double> univec(num_row);
+      for (int i = 0; i < num_row; ++i) univec[i] = xMatrix(i, 0);
+      std::vector<std::vector<double>> unimat = GridVec2Mat(univec,numRows);
+      auto embedding = GenGridEmbeddingsCom(unimat, E, tau, style);
+
+      // Initialize stacked_vec with correct shape
+      stacked_vec = std::move(embedding);
+    }
+
+    // Start from variable index 1 since index 0 is initialized
+    for (int n = 1; n < num_var; ++n) {
+      // Extract variable column
       std::vector<double> univec(num_row);
       for (int i = 0; i < num_row; ++i) univec[i] = xMatrix(i, n);
       std::vector<std::vector<double>> unimat = GridVec2Mat(univec,numRows);
 
-      // Generate 3D embeddings for this variable
-      std::vector<std::vector<std::vector<double>>> embedding = GenGridEmbeddingsCom(unimat, E, tau, style);
-      stacked_vec.insert(
-        stacked_vec.end(),
-        std::make_move_iterator(embedding.begin()),
-        std::make_move_iterator(embedding.end())
-      );
+      // Get embedding for this variable
+      auto embedding = GenGridEmbeddingsCom(unimat, E, tau, style);
+
+      // Append each embedding block column-wise
+      for (size_t j = 0; j < stacked_vec.size(); ++j) {
+        // Each stacked_vec[j] and embedding[j] must share same row count
+        for (size_t r = 0; r < stacked_vec[j].size(); ++r) {
+          // Append columns from embedding[j][r] to stacked_vec[j][r]
+          stacked_vec[j][r].insert(
+              stacked_vec[j][r].end(),
+              std::make_move_iterator(embedding[j][r].begin()),
+              std::make_move_iterator(embedding[j][r].end())
+          );
+        }
+      }
     }
 
     // Perform multi-view embedding (3D version)


### PR DESCRIPTION
This PR corrects the logic for constructing stacked 3D embeddings in **Grid mode** (`GenGridEmbeddingsCom`).
The previous implementation appended each variable’s embedding using:

```cpp
stacked_vec.insert(
    stacked_vec.end(),
    std::make_move_iterator(embedding.begin()),
    std::make_move_iterator(embedding.end())
);
```

This incorrectly **increased the number of embedding subsets** rather than stacking additional embedding **columns** for existing subsets.

As a resulting bug:

* Embedding structure became misaligned (`nb_vec` changed incorrectly)
* Multi-view embedding received wrongly shaped data
* Row-wise temporal structure was potentially corrupted

---

#### ✅ What this PR changes

The new implementation:

* Initializes `stacked_vec` using the first variable’s embedding
* For subsequent variables, embeds and **appends columns** to existing rows:

```cpp
// stacked_vec: [embedding_subset][row][col]
stacked_vec[j][r].insert(
    stacked_vec[j][r].end(),
    std::make_move_iterator(embedding[j][r].begin()),
    std::make_move_iterator(embedding[j][r].end())
);
```

#### Resulting data shape

If single-variable Grid embedding returns:

```
[nb_vec][num_row][cols_per_var]
```

Then final result now correctly becomes:

```
[nb_vec][num_row][cols_per_var * num_var]
```

---

#### ✅ Benefits

* Fixes structure for multi-variable Grid embeddings
* Maintains row/time alignment across variables
* Preserves original embedding subset count (`nb_vec`)
* More consistent with 2D embedding mode behavior
* Efficient memory moves (no unnecessary deep copies)

---

#### Code snippet included in this PR

```cpp
// Initialize stacked_vec based on variable 0...
stacked_vec = std::move(embedding);
// Append embedding columns for variables 1..num_var-1...
stacked_vec[j][r].insert(...);
```
