### PR TITLE
remove all examples and vignettes using cu variables to reduce package size

### DIFF
--- a/R/embedded.R
+++ b/R/embedded.R
@@ -44,7 +44,7 @@
 #'
 #' npp = terra::rast(system.file("case/npp.tif", package="spEDM"))
 #' r = embedded(npp,"npp")
-#' r[which(!is.na(r),arr.ind = T)[1:5],]
+#' r[which(!is.na(r),arr.ind = TRUE)[1:5],]
 #'
 methods::setMethod("embedded", "sf", .embedded_sf_method)
 

--- a/man/embedded.Rd
+++ b/man/embedded.Rd
@@ -63,6 +63,6 @@ v[1:5,]
 
 npp = terra::rast(system.file("case/npp.tif", package="spEDM"))
 r = embedded(npp,"npp")
-r[which(!is.na(r),arr.ind = T)[1:5],]
+r[which(!is.na(r),arr.ind = TRUE)[1:5],]
 
 }


### PR DESCRIPTION
Retain three sample datasets (`csv` table, `gpkg` vector, `tif` raster) in the package to support usage demonstration.