### PR TITLE
change pattern storage in generic `gpc` results to use nested dataframes instead of arrays

### DIFF
--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -254,7 +254,7 @@
     res_bi$summary$direction = "x_xmap_y"
     res$causality = rbind(res$causality,res_bi$causality)
     res$summary = rbind(res$summary,res_bi$summary)
-    res$pattern$x_xmap_y = as.data.frame(res_bi$pattern)
+    res$pattern$x_xmap_y = res_bi$pattern$y_xmap_x
   }
 
   class(res) = "pc_res"


### PR DESCRIPTION
- change pattern storage in generic `gpc` results to use nested dataframes instead of arrays
- preserve row and column names when store pattern results