### PR TITLE
fix incorrect column names in the return results

### DIFF
--- a/src/GridExp.cpp
+++ b/src/GridExp.cpp
@@ -1312,7 +1312,7 @@ Rcpp::NumericMatrix RcppPC4Grid(const Rcpp::NumericMatrix& source,
   }
 
   // Set column names for the result matrix
-  Rcpp::colnames(result) = Rcpp::CharacterVector::create("E", "k", "CausalScore", "Significance");
+  Rcpp::colnames(result) = Rcpp::CharacterVector::create("E", "k", "tau", "positive", "negative", "dark");
   return result;
 }
 


### PR DESCRIPTION
This PR fix incorrect column names in the return results of the spatial grid implementation for optimal parameter selection in geographical pattern causality analysis.