### PR TITLE
remove redundant deduplicate call after unordered set to vector conversion

### DIFF
--- a/src/CppLatticeUtils.cpp
+++ b/src/CppLatticeUtils.cpp
@@ -43,7 +43,7 @@ std::vector<std::vector<int>> CppLaggedNeighbor4Lattice(const std::vector<std::v
     return result;
   }
 
-  // // Handle lagNum=1: return the immediate neighbors directly
+  // // Handle lagNum=1: return the immediate neighbors directly, as now returned cumulated lagged neighbours
   // if (lagNum == 1) {
   //   return spNeighbor;
   // }
@@ -88,10 +88,9 @@ std::vector<std::vector<int>> CppLaggedNeighbor4Lattice(const std::vector<std::v
       mergedSet.insert(elem);
     }
 
-    // Convert set to sorted vector and deduplicate
+    // Convert unordered set to sorted vector
     std::vector<int> vec(mergedSet.begin(), mergedSet.end());
     std::sort(vec.begin(), vec.end());
-    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 
     // Handle empty result by filling with min value
     if (vec.empty()) {
@@ -279,10 +278,9 @@ std::vector<std::vector<double>> GenLatticeEmbeddings(
           mergedSet.insert(elem);
         }
 
-        // Convert set to sorted vector and deduplicate
+        // Convert unordered set to sorted vector
         std::vector<int> vec(mergedSet.begin(), mergedSet.end());
         std::sort(vec.begin(), vec.end());
-        vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 
         // Handle empty result by filling with min value
         if (vec.empty()) {


### PR DESCRIPTION
This PR eliminates an unnecessary `std::unique()` call following conversion from `std::unordered_set<int>` to `std::vector<int>` in the spatial lagged neighbor expansion logic. Since `unordered_set` guarantees element uniqueness by construction (duplicate insertions are silently discarded), the subsequent `unique() + erase()` sequence performed redundant linear scans without functional benefit.

**Changes:**
- Removed `newIndices.erase(std::unique(...), ...)` after `unordered_set → vector` conversion
- Preserved explicit sorting to maintain deterministic output order required for scientific reproducibility