### PR TITLE
remove sf/terra preloading from .onLoad, keep only Rcpp

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,3 @@
-.onLoad = function(...) {
-  loadNamespace("sf")
-  loadNamespace("terra")
+.onLoad = \(...) {
+  requireNamespace("Rcpp", quietly = TRUE)
 }


### PR DESCRIPTION
- Remove proactive loading of `sf` and `terra` namespaces from .onLoad
- Ensure `Rcpp` C++ wrappers are correctly linked during package initialization
- Prevent premature PROJ/GDAL database context setup that triggered macOS CI warnings
- Reduce package startup overhead and improve cross-platform R CMD check stability