### PR TITLE
use queen contiguity to construct default nb when required but not provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### enhancements
 
+* Use queen contiguity to construct default `nb` when required but not provided (#1007).
+
 * Integrate accepted IJGIS publication details for geographical cross mapping cardinality (#1005).
 
 * No longer loads the `sf` and `terra` namespaces when loading `spEDM` package (#1000).

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -43,14 +43,7 @@
   return(.varname)
 }
 
-.internal_lattice_nb = \(data){
-  if (sdsfun::sf_geometry_type(data) %in% c('point','multipoint')){
-    nb = sdsfun::spdep_nb(data,k = 8)
-  } else {
-    nb = sdsfun::spdep_nb(data)
-  }
-  return(nb)
-}
+.internal_lattice_nb = \(data) sdsfun::spdep_nb(data)
 
 .internal_grid2df = \(data, grid.coord = TRUE){
   if (grid.coord) {


### PR DESCRIPTION
This PR updates the default neighbor object (`nb`) construction logic when a neighbor object (`nb`) is required but not supplied by the user, the package now defaults to queen contiguity for polygon data. For point data, it first constructs a Delaunay triangulation and then derives the Queen contiguity from the resulting triangles.

## Changes
- **Previous behavior**: The package defaulted to constructing an `nb` object for (multi)-point data using the **8 nearest neighbors (k=8 knn)**.
- **New behavior**: 
  - For **polygon data** (*no change*): Defaults to **Queen contiguity** (sharing at least one vertex).
  - For **point data**: First constructs **Thiessen polygons (Voronoi tessellation)**, and then derives the **Queen contiguity** from the resulting polygons.

## Benefits
1. **Topological Consistency**: Queen contiguity is based on actual geometric boundaries rather than an arbitrary fixed number of neighbors (like k=8). This prevents artificial long-range connections in sparse regions and ensures fully connected graphs in dense regions.
2. **Better Spatial Representation for Points**: For point data, using Thiessen polygons ensures that neighbor relationships respect the natural spatial proximity and convex hull of the point pattern, avoiding the boundary artifacts and "kink" effects often seen in fixed k-NN graphs.
3. **Alignment with Spatial Standards**: Queen contiguity is the standard default in spatial econometrics and spatial statistics (e.g., in `spdep`), making the package's behavior more intuitive and consistent with established literature for areal data.