### PR TITLE
fix incorrect auto-filling of default E, tau, k parameter lengths in SCPCM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 ### bug fixes
 
-* fix incorrect auto-filling of default E, tau, k parameter lengths in SCPCM (#1009).
+* Fix incorrect auto-filling of default `E`, `tau`, `k` parameters in SCPCM (#1009).
 
 # spEDM 1.12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * Clarify output indexing and boundary handling in `fnn` generic via console output modification (#999).
 
+### bug fixes
+
+* fix incorrect auto-filling of default E, tau, k parameter lengths in SCPCM (#1009).
+
 # spEDM 1.12
 
 ### new

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 ### bug fixes
 
-* Fix incorrect auto-filling of default `E`, `tau`, `k` parameters in SCPCM (#1009).
+* Fix incorrect auto-filling of default `E`, `tau`, `k` parameters in `scpcm` generic (#1009).
 
 # spEDM 1.12
 

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -9,12 +9,14 @@
 }
 
 .check_inputelementnum = \(x,n,condsnum = NULL){
-  if (is.null(condsnum) || length(x) == 1){
+  if (is.null(condsnum)){
     res = rep(x,length.out = n)
+  } else if (length(x) == 1) {
+    res = rep(x,length.out = 2 + condsnum)
   } else if (length(x) == 2) {
     res = c(rep(x[1],2),rep(x[2],condsnum))
   } else {
-    res = c(x[1:2],rep(x[c(-1,-2)],length.out = condsnum))
+    res = c(x[1:2],rep(rev(x[c(-1,-2)]),length.out = condsnum))
   }
   return(res)
 }


### PR DESCRIPTION
This PR fixes a critical bug in the auto-filling (recycling) logic for the embedding dimension (`E`), spatial lag step (`tau`), and number of neighbors (`k`) parameters in the *Spatially Convergent Partial Cross Mapping (SCPCM)* method.

The new logic intelligently handles parameter expansion based on the input length:
- **Length 1**: The single value is applied to all variables (cause, effect, and all controls).
- **Length 2**: The first value is assigned to `cause` and `effect`; the second value is recycled for all `controls`. (Highly useful for setting different embedding dimensions for target vs. control variables).
- **Length ≥ 3**: The first two values are assigned to `cause` and `effect`; the remaining values are recycled specifically for the `controls`.